### PR TITLE
adjusting prefetch ttl

### DIFF
--- a/src/js/typeahead.js
+++ b/src/js/typeahead.js
@@ -49,6 +49,7 @@
             limit: datasetDef.limit,
             local: datasetDef.local,
             prefetch: datasetDef.prefetch,
+            ttl_ms: datasetDef.ttl_ms,
             remote: datasetDef.remote,
             matcher: datasetDef.matcher,
             ranker: datasetDef.ranker,


### PR DESCRIPTION
This change that allows the ttl for prefetched data to be adjusted by adding `ttl_ms` to a dataset.

``` javascript
$('.typeahead').typeahead({                                
  name: 'countries',
  prefetch: '../data/countries.json',
  ttl_ms: 60 * 60 * 1e3, // 1 hour instead of 3 days
});
```
