### PR TITLE
store full received data object on suggestion items, not just 'value' ke...

### DIFF
--- a/src/js/dropdown_view.js
+++ b/src/js/dropdown_view.js
@@ -71,7 +71,7 @@ var DropdownView = (function() {
       }
 
       $underCursor = $suggestions.eq(nextIndex).addClass('tt-is-under-cursor');
-      this.trigger('cursorOn', { value: $underCursor.data('value') });
+      this.trigger('cursorOn', $underCursor.data());
     },
 
     _getSuggestions: function() {
@@ -164,7 +164,11 @@ var DropdownView = (function() {
           elBuilder.innerHTML = dataset.template.render(suggestion);
 
           el = elBuilder.firstChild;
-          el.setAttribute('data-value', suggestion.value);
+          for (var key in suggestion) {
+            if (key != 'query' & key != 'dataset') {
+              el.setAttribute('data-'+key, suggestion[key]);
+            }
+          }
 
           fragment.appendChild(el);
         });
@@ -193,11 +197,9 @@ var DropdownView = (function() {
 
   function formatDataForSuggestion($suggestion) {
     var $suggestions = $suggestion.parents('.tt-suggestions').first();
-
-    return {
-      value: $suggestion.data('value'),
-      query: $suggestions.data('query'),
-      dataset: $suggestions.data('dataset')
-    };
+    var data = $suggestion.data();
+    data.query = $suggestions.data('query');
+    data.dataset = $suggestions.data('dataset');
+    return data;
   }
 })();

--- a/test/dropdown_view_spec.js
+++ b/test/dropdown_view_spec.js
@@ -3,9 +3,9 @@ describe('DropdownView', function() {
     '<ol class="tt-dropdown-menu">',
       '<li class="tt-dataset-test">',
         '<ol class="tt-suggestions" data-query="test q" data-dataset="test">',
-          '<li class="tt-suggestion" data-value="one">one</li>',
-          '<li class="tt-suggestion" data-value="two">two</li>',
-          '<li class="tt-suggestion" data-value="three">three</li>',
+          '<li class="tt-suggestion" data-value="one" data-arbitrary="first">one</li>',
+          '<li class="tt-suggestion" data-value="two" data-arbitrary="second">two</li>',
+          '<li class="tt-suggestion" data-value="three" data-arbitrary="third">three</li>',
         '</ol>',
       '</li>',
     '</ol>'
@@ -88,7 +88,8 @@ describe('DropdownView', function() {
         data: {
           query: 'test query',
           dataset: 'test dataset',
-          value: 'one'
+          value: 'one',
+          arbitrary: 'first'
         }
       });
     });
@@ -432,6 +433,7 @@ describe('DropdownView', function() {
         var suggestionData = this.dropdownView.getSuggestionUnderCursor();
 
         expect(suggestionData.value).toBe($suggestion.data('value'));
+        expect(suggestionData.arbitrary).toBe($suggestion.data('arbitrary'));
         expect(suggestionData.query).toBe(this.$testSet.data('query'));
         expect(suggestionData.dataset).toBe(this.$testSet.data('dataset'));
       });
@@ -445,6 +447,7 @@ describe('DropdownView', function() {
           suggestionData = this.dropdownView.getFirstSuggestion();
 
       expect(suggestionData.value).toBe($firstSuggestion.data('value'));
+      expect(suggestionData.arbitrary).toBe($firstSuggestion.data('arbitrary'));
       expect(suggestionData.query).toBe(this.$testSet.data('query'));
       expect(suggestionData.dataset).toBe(this.$testSet.data('dataset'));
     });


### PR DESCRIPTION
...y.

This allow to pass a number of attributes to suggestions, and retrieve them later when suggestion is selected (for example: an url to go to for a particular item; a category to filter on if 'enter' key should go to a search page).
