### PR TITLE
Missing wrapper to define $ as jQuery

### DIFF
--- a/src/js/intro.js
+++ b/src/js/intro.js
@@ -4,4 +4,4 @@
  * Copyright 2013 Twitter, Inc. and other contributors; Licensed MIT
  */
 
-(function() {
+(function($) {

--- a/src/js/outro.js
+++ b/src/js/outro.js
@@ -4,4 +4,4 @@
  * Copyright 2013 Twitter, Inc. and other contributors; Licensed MIT
  */
 
-})();
+})(jQuery);


### PR DESCRIPTION
- Some sites use both Prototype and jQuery. This wrapper helps avoiding confusions when not using the $ variable as jQuery.
