### PR TITLE
Error thrown when typeahead is initialized on multiple elements

### DIFF
--- a/src/js/typeahead.js
+++ b/src/js/typeahead.js
@@ -37,8 +37,6 @@
 
         else {
           datasetDef.limit = datasetDef.limit || 5;
-          datasetDef.template = datasetDef.template;
-          datasetDef.engine = datasetDef.engine;
 
           if (datasetDef.template && !datasetDef.engine) {
             throw new Error('no template engine specified for ' + name);
@@ -60,8 +58,7 @@
         datasets[name] = {
           name: datasetDef.name,
           limit: datasetDef.limit,
-          template: datasetDef.template,
-          engine: datasetDef.engine,
+          template: compileTemplate(datasetDef.template, datasetDef.engine),
           getSuggestions: dataset.getSuggestions
         };
       });
@@ -86,5 +83,26 @@
 
   function configureTransport(o) {
     transportOptions = o;
+  }
+
+  function compileTemplate(template, engine) {
+    var wrapper = '<li class="tt-suggestion">%body</li>',
+       compiledTemplate;
+
+    if (template) {
+      compiledTemplate = engine.compile(wrapper.replace('%body', template));
+    }
+
+    // if no template is provided, render suggestion
+    // as its value wrapped in a p tag
+    else {
+      compiledTemplate = {
+        render: function(context) {
+          return wrapper.replace('%body', '<p>' + context.value + '</p>');
+        }
+      };
+    }
+
+    return compiledTemplate;
   }
 })();

--- a/src/js/typeahead_view.js
+++ b/src/js/typeahead_view.js
@@ -16,42 +16,18 @@ var TypeaheadView = (function() {
   // -----------
 
   function TypeaheadView(o) {
+    var $menu, $input, $hint;
+
     utils.bindAll(this);
 
     this.$node = wrapInput(o.input);
     this.datasets = o.datasets;
 
-    // precompile the templates
-    utils.each(this.datasets, function(key, dataset) {
-      var parentTemplate = '<li class="tt-suggestion">%body</li>';
+    $menu = this.$node.find('.tt-dropdown-menu');
+    $input = this.$node.find('.tt-query');
+    $hint = this.$node.find('.tt-hint');
 
-      if (dataset.template) {
-        dataset.template = dataset.engine
-        .compile(parentTemplate.replace('%body', dataset.template));
-      }
-
-      // if no template is provided, render suggestion
-      // as it's value wrapped in a p tag
-      else {
-        dataset.template = {
-          render: function(context) {
-            return parentTemplate
-            .replace('%body', '<p>' + context.value + '</p>');
-          }
-        };
-      }
-    });
-
-    this.inputView = new InputView({
-      input: this.$node.find('.tt-query'),
-      hint: this.$node.find('.tt-hint')
-    });
-
-    this.dropdownView = new DropdownView({
-      menu: this.$node.find('.tt-dropdown-menu')
-    });
-
-    this.dropdownView
+    this.dropdownView = new DropdownView({ menu: $menu })
     .on('select', this._handleSelection)
     .on('cursorOn', this._clearHint)
     .on('cursorOn', this._setInputValueToSuggestionUnderCursor)
@@ -61,7 +37,7 @@ var TypeaheadView = (function() {
     .on('show', this._updateHint)
     .on('hide', this._clearHint);
 
-    this.inputView
+    this.inputView = new InputView({ input: $input, hint: $hint })
     .on('focus', this._showDropdown)
     .on('blur', this._hideDropdown)
     .on('blur', this._setInputValueToQuery)

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -17,7 +17,7 @@ var utils = {
 
   isFunction: $.isFunction,
 
-  isObject: function(obj) { return obj === Object(obj); },
+  isObject: $.isPlainObject,
 
   isUndefined: function(obj) { return typeof obj === 'undefined'; },
 
@@ -26,7 +26,7 @@ var utils = {
   bindAll: function(obj) {
     var val;
     for (var key in obj) {
-      utils.isFunction(val = obj[key]) && (obj[key] = $.proxy(val, obj));
+      $.isFunction(val = obj[key]) && (obj[key] = $.proxy(val, obj));
     }
   },
 


### PR DESCRIPTION
Fixes #42. Previously, the following code wouldn't work as expected:

``` html
<input class="typeahead">
<input class="typeahead">

<script>
  $('.typeahead').typeahead({ /* ... */ })
</script>
```
