### PR TITLE
Resolved Issue #22 - Added 'selection' callback and event

### DIFF
--- a/src/js/dropdown_view.js
+++ b/src/js/dropdown_view.js
@@ -197,7 +197,8 @@ var DropdownView = (function() {
     return {
       value: $suggestion.data('value'),
       query: $suggestions.data('query'),
-      dataset: $suggestions.data('dataset')
+      dataset: $suggestions.data('dataset'),
+      index: $suggestions.children().index($suggestion)
     };
   }
 })();

--- a/src/js/typeahead.js
+++ b/src/js/typeahead.js
@@ -62,7 +62,8 @@
           limit: datasetDef.limit,
           template: datasetDef.template,
           engine: datasetDef.engine,
-          getSuggestions: dataset.getSuggestions
+          getSuggestions: dataset.getSuggestions,
+          selectionCallback: datasetDef.selectionCallback
         };
       });
 

--- a/src/js/typeahead_view.js
+++ b/src/js/typeahead_view.js
@@ -12,6 +12,8 @@ var TypeaheadView = (function() {
     dropdown: '<ol class="tt-dropdown-menu tt-is-empty"></ol>'
   };
 
+  var renderedSuggestions = [];
+
   // constructor
   // -----------
 
@@ -172,6 +174,7 @@ var TypeaheadView = (function() {
     },
 
     _handleSelection: function(e) {
+      var query, selectedItem, dataset, selectionCallback;
       var byClick = e.type === 'select',
           suggestionData = byClick ?
             e.data : this.dropdownView.getSuggestionUnderCursor();
@@ -188,6 +191,19 @@ var TypeaheadView = (function() {
         // focus is not a synchronous event in ie, so we deal with it
         byClick && utils.isMsie() ?
           setTimeout(this.dropdownView.hide, 0) : this.dropdownView.hide();
+
+        query = suggestionData.query;
+        selectedItem = renderedSuggestions[suggestionData.index] || renderedSuggestions[0];
+
+        selectionCallback = this.datasets[suggestionData.dataset].selectionCallback;
+        if (selectionCallback && typeof selectionCallback === 'function') {
+          selectionCallback(query, selectedItem);
+        }
+
+        this.inputView.$input.trigger(jQuery.Event('selection', {
+          query: query,
+          selectedItem: selectedItem
+        }));
       }
     },
 
@@ -205,7 +221,7 @@ var TypeaheadView = (function() {
     _renderSuggestions: function(query, dataset, suggestions) {
       if (query !== this.inputView.getQuery()) { return; }
 
-      suggestions = suggestions.slice(0, dataset.limit);
+      suggestions = renderedSuggestions = suggestions.slice(0, dataset.limit);
       this.dropdownView.renderSuggestions(query, dataset, suggestions);
     },
 


### PR DESCRIPTION
Added a selection callback:

``` javascript
  $('.example-countries .typeahead').typeahead({
    name: 'countries',
    prefetch: '../data/countries.json',
    limit: 10,
    selectionCallback: function(query, selectedItem) {
      console.log(query, selectedItem);
    }
  });
```

Also, added a 'selection' event:

``` javascript
  $('.example-twitter-oss .typeahead').typeahead({
    name: 'twitter-oss',
    prefetch: '../data/repos.json',
    template: [
      '<p class="repo-language">{{language}}</p>',
      '<p class="repo-name">{{name}}</p>',
      '<p class="repo-description">{{description}}</p>'
    ].join(''),
    engine: Hogan
  });

  $('.example-twitter-oss .typeahead').bind('selection', function(evt) {
    console.log(evt.query, evt.selectedItem);
  });
```
