### PR TITLE
Fix some input value oddities

### DIFF
--- a/src/input_view.js
+++ b/src/input_view.js
@@ -192,8 +192,8 @@ var InputView = (function() {
 
   function compareQueries(a, b) {
     // strips leading whitespace and condenses all whitespace
-    a = (a || '').replace(/^\s*/g, '').replace(/\s{2,}/g, ' ').toLowerCase();
-    b = (b || '').replace(/^\s*/g, '').replace(/\s{2,}/g, ' ').toLowerCase();
+    a = (a || '').replace(/^\s*/g, '').replace(/\s{2,}/g, ' ');
+    b = (b || '').replace(/^\s*/g, '').replace(/\s{2,}/g, ' ');
 
     return a === b;
   }


### PR DESCRIPTION
Along with the issue mentioned towards the end of #107, this fixes a previously unreported bug where if you change the casing of a letter in your query, the hint would get messed up.
