### PR TITLE
Don't throw an error if initialized on 0 elements

### DIFF
--- a/src/typeahead.js
+++ b/src/typeahead.js
@@ -13,10 +13,6 @@
 
       datasetDefs = utils.isArray(datasetDefs) ? datasetDefs : [datasetDefs];
 
-      if (this.length === 0) {
-        $.error('typeahead initialized without DOM element');
-      }
-
       if (datasetDefs.length === 0) {
         $.error('no datasets provided');
       }


### PR DESCRIPTION
Based on a discussion in #136, I'm removing this behavior.
