### PR TITLE
Wrap localStorage check in try/catch.

### DIFF
--- a/src/persistent_storage.js
+++ b/src/persistent_storage.js
@@ -5,15 +5,21 @@
  */
 
 var PersistentStorage = (function() {
-  var ls = window.localStorage, methods;
+  var ls, methods;
 
+  try {
+    ls = window.localStorage;
+  } catch (err) {
+    ls = null;
+  }
+  
   function PersistentStorage(namespace) {
     this.prefix = ['__', namespace, '__'].join('');
     this.ttlKey = '__ttl__';
     this.keyMatcher = new RegExp('^' + this.prefix);
   }
 
-  if (window.localStorage && window.JSON) {
+  if (ls && window.JSON) {
     methods = {
 
       // private methods


### PR DESCRIPTION
In Chrome with cookies disabled, accessing `window.localStorage` throws a DOM security error 18. This wraps the feature test up in a try/catch block so it can carry on its way, setting the methods with `utils.noop`.

Addresses issue https://github.com/twitter/typeahead.js/issues/189
