### PR TITLE
Allow duplicates

### DIFF
--- a/src/dataset.js
+++ b/src/dataset.js
@@ -42,6 +42,8 @@ var Dataset = (function() {
     // only initialize storage if there's a name otherwise
     // loading from storage on subsequent page loads is impossible
     this.storage = o.name ? new PersistentStorage(o.name) : null;
+	
+    this.allowDuplicates = o.allowDuplicates || false;
   }
 
   utils.mixin(Dataset.prototype, {
@@ -277,7 +279,7 @@ var Dataset = (function() {
           var item = that._transformDatum(datum), isDuplicate;
 
           // checks for duplicates
-          isDuplicate = utils.some(suggestions, function(suggestion) {
+          isDuplicate = that.allowDuplicates ? false : utils.some(suggestions, function(suggestion) {
             return item.value === suggestion.value;
           });
 


### PR DESCRIPTION
I needed a way to show what typeahead deemed to be duplicate datums, so I added an option in for allowing duplicate datums to be displayed
