### PR TITLE
attaching the respective dataset to rendered suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $('input.typeahead-devs').typeahead('destroy');
 
 ### Dataset
 
-A dataset is an object that defines a set of data that hydrates suggestions. Typeaheads can be backed by multiple datasets. Given a query, a typeahead instance will inspect its backing datasets and display relevant suggestions to the end-user. 
+A dataset is an object that defines a set of data that hydrates suggestions. Typeaheads can be backed by multiple datasets. Given a query, a typeahead instance will inspect its backing datasets and display relevant suggestions to the end-user.
 
 When defining a dataset, the following options are available:
 
@@ -189,9 +189,9 @@ typeahead.js triggers the following custom events:
 
 * `typeahead:closed` – Triggered when the dropdown menu of a typeahead is closed.
 
-* `typeahead:selected` – Triggered when a suggestion from the dropdown menu is explicitly selected. The datum for the selected suggestion is passed to the event handler as an argument.
+* `typeahead:selected` – Triggered when a suggestion from the dropdown menu is explicitly selected. The datum for the selected suggestion and the dataset it belongs to are passed to the event handler as an argument.
 
-* `typeahead:autocompleted` – Triggered when the query is autocompleted. The datum used for autocompletion is passed to the event handler as an argument.
+* `typeahead:autocompleted` – Triggered when the query is autocompleted. The datum used for autocompletion and the dataset it belongs to are passed to the event handler as an argument.
 
 All custom events are triggered on the element initialized as a typeahead.
 

--- a/src/dropdown_view.js
+++ b/src/dropdown_view.js
@@ -206,6 +206,8 @@ var DropdownView = (function() {
         fragment = document.createDocumentFragment();
 
         utils.each(suggestions, function(i, suggestion) {
+          suggestion.dataset = dataset.name;
+
           compiledHtml = dataset.template(suggestion.datum);
           elBuilder.innerHTML = wrapper.replace('%body', compiledHtml);
 

--- a/src/typeahead_view.js
+++ b/src/typeahead_view.js
@@ -217,7 +217,7 @@ var TypeaheadView = (function() {
         byClick && utils.isMsie() ?
           utils.defer(this.dropdownView.close) : this.dropdownView.close();
 
-        this.eventBus.trigger('selected', suggestion.datum);
+        this.eventBus.trigger('selected', suggestion.datum, suggestion.dataset);
       }
     },
 
@@ -254,7 +254,7 @@ var TypeaheadView = (function() {
         suggestion = this.dropdownView.getFirstSuggestion();
         this.inputView.setInputValue(suggestion.value);
 
-        this.eventBus.trigger('autocompleted', suggestion.datum);
+        this.eventBus.trigger('autocompleted', suggestion.datum, suggestion.dataset);
       }
     },
 

--- a/test/dropdown_view_spec.js
+++ b/test/dropdown_view_spec.js
@@ -78,7 +78,12 @@ describe('DropdownView', function() {
     it('should trigger suggestionSelected', function() {
       expect(this.spy).toHaveBeenCalledWith({
         type: 'suggestionSelected',
-        data: { value: 'one', tokens: ['one'], datum: { value: 'one' } }
+        data: {
+          value: 'one',
+          tokens: ['one'],
+          datum: { value: 'one' },
+          dataset: 'test'
+        }
       });
     });
   });
@@ -434,7 +439,8 @@ describe('DropdownView', function() {
         expect(suggestion).toEqual({
           value: 'one',
           tokens: ['one'],
-          datum: { value: 'one' }
+          datum: { value: 'one' },
+          dataset: 'test'
         });
       });
     });
@@ -451,7 +457,8 @@ describe('DropdownView', function() {
       expect(suggestion).toEqual({
         value: 'one',
         tokens: ['one'],
-        datum: { value: 'one' }
+        datum: { value: 'one' },
+        dataset: 'test'
       });
     });
   });


### PR DESCRIPTION
I need to know from which dataset the suggestion originated and currently there's no way to accomplish that. This pull request attempts to solve that problem by passing the relevant dataset as a second argument to the `typeahead:selected` and `typeahead:autocompleted` events
