### PR TITLE
Document jQuery#typeahead('setQuery')

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ $('input.typeahead-devs').typeahead({
 $('input.typeahead-devs').typeahead('destroy');
 ```
 
+#### jQuery#typeahead('setQuery', query)
+
+Sets the current query of the typeahead. This is always preferable to using `$("input.typeahead").val(query)`, which will result in unexpected behavior. To clear the query, simply set it to an empty string.
+
 ### Dataset
 
 A dataset is an object that defines a set of data that hydrates suggestions. Typeaheads can be backed by multiple datasets. Given a query, a typeahead instance will inspect its backing datasets and display relevant suggestions to the end-user. 


### PR DESCRIPTION
Was surprised the only mention of this method was in [this closed issue](https://github.com/twitter/typeahead.js/issues/126). Added it to the docs to save future headaches :)
