### PR TITLE
Remove `tt-is-under-cursor` class when mouse leaves suggestions

### DIFF
--- a/src/dropdown_view.js
+++ b/src/dropdown_view.js
@@ -28,7 +28,8 @@ var DropdownView = (function() {
     .on('mouseenter.tt', this._handleMouseenter)
     .on('mouseleave.tt', this._handleMouseleave)
     .on('click.tt', '.tt-suggestion', this._handleSelection)
-    .on('mouseover.tt', '.tt-suggestion', this._handleMouseover);
+    .on('mouseover.tt', '.tt-suggestion', this._handleMouseover)
+    .on('mouseleave.tt', '.tt-suggestion', this._handleSuggestionMouseleave);
   }
 
   utils.mixin(DropdownView.prototype, EventTarget, {
@@ -46,8 +47,11 @@ var DropdownView = (function() {
     _handleMouseover: function($e) {
       var $suggestion = $($e.currentTarget);
 
-      this._getSuggestions().removeClass('tt-is-under-cursor');
       $suggestion.addClass('tt-is-under-cursor');
+    },
+
+    _handleSuggestionMouseleave: function() {
+      this._getSuggestions().removeClass('tt-is-under-cursor');
     },
 
     _handleSelection: function($e) {

--- a/test/dropdown_view_spec.js
+++ b/test/dropdown_view_spec.js
@@ -50,6 +50,7 @@ describe('DropdownView', function() {
       // start with suggestion1 highlighted
       this.$suggestion1.addClass('tt-is-under-cursor');
 
+      this.$suggestion1.mouseleave();
       this.$suggestion2.mouseover();
     });
 


### PR DESCRIPTION
This fixes the problem where the last moused over suggestion stays highlighted when the mouse leaves the suggestions, which looks especially wrong when mousing over a dropdown with a link in the footer.
