### PR TITLE
Filter out tab + modifier presses, #303

### DIFF
--- a/src/typeahead_view.js
+++ b/src/typeahead_view.js
@@ -200,11 +200,22 @@ var TypeaheadView = (function() {
     },
 
     _handleSelection: function(e) {
-      var byClick = e.type === 'suggestionSelected',
-          suggestion = byClick ?
-            e.data : this.dropdownView.getSuggestionUnderCursor();
+      var byClick = e.type === 'suggestionSelected';
 
-      if (suggestion) {
+      var suggestion, modifierPressed;
+
+      if(byClick){
+        suggestion = e.data;
+        modifierPressed = false;
+      } 
+
+      else {
+        suggestion = this.dropdownView.getSuggestionUnderCursor();
+        var $e = e.data;
+        modifierPressed = $e.shiftKey || $e.ctrlKey || $e.metaKey || $e.altKey;
+      }
+
+      if (suggestion && !modifierPressed) {
         this.inputView.setInputValue(suggestion.value);
 
         // if triggered by click, ensure the query input still has focus


### PR DESCRIPTION
Attempt to fix issue #303 to prevent modifier + tab selections from going through.  Tested in playground and full test suite passes.
