### PR TITLE
Add ajaxSettings to remote options

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ When configuring `remote`, the following options are available:
 
 * `filter` – A function with the signature `filter(parsedResponse)` that transforms the response body into an array of datums. Expected to return an array of datums.
 
+* `ajaxSettings` - An object that will set other properties of the `jQuery.ajax` request.
+
 ### Custom Events
 
 typeahead.js triggers the following custom events:

--- a/src/transport.js
+++ b/src/transport.js
@@ -26,13 +26,13 @@ var Transport = (function() {
     this.filter = o.filter;
     this.replace = o.replace;
 
-    this.ajaxSettings = {
+    this.ajaxSettings = utils.mixin(o.ajaxSettings || {}, {
       type: 'get',
       cache: o.cache,
       timeout: o.timeout,
       dataType: o.dataType || 'json',
       beforeSend: o.beforeSend
-    };
+    });
 
     this._get = (/^throttle$/i.test(o.rateLimitFn) ?
       utils.throttle : utils.debounce)(this._get, o.rateLimitWait || 300);


### PR DESCRIPTION
This allows for an an object called `ajaxSettings` to be set in the remote options which allows arbitrary setting of options that will be passed to the `jQuery.ajax` request.

I had the specific need for this because I needed to set the `jsonp` on the jQuery request to override the name of the callback function.

I figured rather than adding another setting to the `remote` options, it might be better to have a catchall that would allow the setting of any of the properties allowed [in the jQuery ajax docs](http://api.jquery.com/jQuery.ajax/).

Also I made it so any specific option set in the `remote` options will override anything in `ajaxSettings` if they have the same key.

Sorry for the lack of tests. I couldn't get the jasmine mock ajax stuff to play nice with jsonp. The `mostRecentAjaxRequest()` was always coming back null.
