### PR TITLE
Hint displays incorrect when query-input has own styles

### DIFF
--- a/src/typeahead_view.js
+++ b/src/typeahead_view.js
@@ -7,7 +7,6 @@
 var TypeaheadView = (function() {
   var html = {
         wrapper: '<span class="twitter-typeahead"></span>',
-        hint: '<input class="tt-hint" type="text" autocomplete="off" spellcheck="off" disabled>',
         dropdown: '<span class="tt-dropdown-menu"></span>'
       },
       css = {
@@ -294,10 +293,25 @@ var TypeaheadView = (function() {
     var $wrapper = $(html.wrapper),
         $dropdown = $(html.dropdown),
         $input = $(input),
-        $hint = $(html.hint);
+        $hint = $(input.clone());
 
     $wrapper = $wrapper.css(css.wrapper);
     $dropdown = $dropdown.css(css.dropdown);
+
+    // prepare hint
+    $hint.removeAttr("id").removeAttr("name");
+    $hint.addClass("tt-hint").attr({
+        autocomplete: "off",
+        spellcheck: false,
+        disabled: "disabled",
+    });
+
+    // remove "data-" attributes
+    var hintData = $hint.data();
+    var hintDataKeys = $.map(hintData , function(value, key) {   return key; });
+    for(i = 0; i < hintDataKeys.length; i++) {
+        $hint.removeAttr("data-" + hintDataKeys[i]);
+    }
 
     $hint
     .css(css.hint)


### PR DESCRIPTION
Problem appears when query-input has inline style or css-class or computed css-style like 

``` css
div input { 
    font-size: 200%; 
    padding: 5px;
}
```

This issue could be fixed if I add cssClasses .tt-query, .tt-hint everywhere in my site.css file.
But what if I don't have access to that file or I want to display few different autocompletes on the page?
Would be fine if plugin can take styles for hint from requested element.
