### PR TITLE
Add typeahead:cursorchanged event

### DIFF
--- a/src/dropdown_view.js
+++ b/src/dropdown_view.js
@@ -102,6 +102,8 @@ var DropdownView = (function() {
 
     _setCursor: function setCursor($el) {
       $el.first().addClass('tt-cursor');
+
+      this.trigger('cursorMoved');
     },
 
     _removeCursor: function removeCursor() {
@@ -137,8 +139,6 @@ var DropdownView = (function() {
       // in the case of scrollable overflow
       // make sure the cursor is visible in the menu
       this._ensureVisible($newCursor);
-
-      this.trigger('cursorMoved');
     },
 
     _ensureVisible: function ensureVisible($el) {

--- a/src/typeahead_view.js
+++ b/src/typeahead_view.js
@@ -75,6 +75,8 @@ var TypeaheadView = (function() {
 
       this.input.clearHint();
       this.input.setInputValue(datum.value, true);
+
+      this.eventBus.trigger('cursorchanged', datum.raw);
     },
 
     _onCursorRemoved: function onCursorRemoved() {

--- a/test/typeahead_view_spec.js
+++ b/test/typeahead_view_spec.js
@@ -69,6 +69,16 @@ describe('TypeaheadView', function() {
       expect(this.input.setInputValue)
       .toHaveBeenCalledWith(testDatum.value, true);
     });
+
+    it('should trigger cursorchanged', function() {
+      var spy;
+
+      this.$input.on('typeahead:cursorchanged', spy = jasmine.createSpy());
+
+      this.dropdown.trigger('cursorMoved');
+
+      expect(spy).toHaveBeenCalled();
+    });
   });
 
   describe('when dropdown triggers cursorRemoved', function() {


### PR DESCRIPTION
Still not 100% sold on the `typeahead:undercursor` event name. If at all possible, I'd like the name to follow the past tense convention of the other events.
