### PR TITLE
Add code coverage via istanbul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 .grunt
 _SpecRunner.html
+/test/coverage
 
 node_modules
 npm-debug.log

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -85,6 +85,27 @@ module.exports = function(grunt) {
           helpers: 'test/helpers/*',
           vendor: 'test/vendor/*'
         }
+      },
+      coverage: {
+        src: jsFiles,
+        options: {
+          specs: 'test/*_spec.js',
+          template: require('grunt-template-jasmine-istanbul'),
+          templateOptions: {
+            coverage: 'test/coverage/coverage.json',
+            report: [
+                    {
+                      type: 'html',
+                        options: {
+                          dir: 'test/coverage/html'
+                        }
+                    },
+                    {
+                      type: 'text-summary'
+                    }
+            ]
+          }
+        }
       }
     },
 
@@ -217,6 +238,7 @@ module.exports = function(grunt) {
   grunt.registerTask('test', 'jasmine:js');
   grunt.registerTask('test:browser', ['jasmine:js:build', 'exec:open_spec_runner']);
   grunt.registerTask('dev', 'parallel:dev');
+  grunt.registerTask('test:coverage', ['jasmine:coverage']);
 
   // load tasks
   // ----------

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "grunt-contrib-connect": "~0.1",
     "grunt-contrib-jasmine": "~0.3",
     "grunt-contrib-clean": "~0.4.0",
+    "grunt-template-jasmine-istanbul": "~0.2.1",
     "semver": "~1.1.3",
     "grunt-parallel": "0.0.2"
   },


### PR DESCRIPTION
I'm trying to better myself this hackweek by messing with Javascript. I tried to add code coverage testing to typeahead.js to see what the state of the art is in Javascript land and came across Istanbul:
http://gotwarlost.github.io/istanbul/

Let me know what you think.

Signed-off-by: Chris Aniszczyk zx@twitter.com
