### PR TITLE
Auto-complete even when hint equals query

### DIFF
--- a/src/typeahead_view.js
+++ b/src/typeahead_view.js
@@ -250,7 +250,7 @@ var TypeaheadView = (function() {
       query = this.inputView.getQuery();
       hint = this.inputView.getHintValue();
 
-      if (hint !== '' && query !== hint) {
+      if (hint !== '') {
         suggestion = this.dropdownView.getFirstSuggestion();
         this.inputView.setInputValue(suggestion.value);
 


### PR DESCRIPTION
_autocomplete checks if the query is not equal to the hint before
setting the input to the first suggestion and firing an event. This
caused an issue for us. The hint is the token, and by default tokens are
all lower cased. If you had typed "foo" and the suggested value was
"Foo", then hit tab, auto-complete would not fire and the input would
remain unchanged with "foo".
