### PR TITLE
Add note to README clarifying tokens entries need to be single words.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ When defining a dataset, the following options are available:
 
 ### Datum
 
-The individual units that compose datasets are called datums. The canonical form of a datum is an object with a `value` property and a `tokens` property. `value` is the string that represents the underlying value of the datum and `tokens` is a collection of strings that aid typeahead.js in matching datums with a given query.
+The individual units that compose datasets are called datums. The canonical form of a datum is an object with a `value` property and a `tokens` property. `value` is the string that represents the underlying value of the datum and `tokens` is a collection of **single-word** strings that aid typeahead.js in matching datums with a given query.
 
 ```javascript
 {


### PR DESCRIPTION
When implementing a typeahead object, I ran into some trouble for awhile because my 'tokens' array had multi-word strings. Typeahead seemed to fail silently. Switching them to single words fixed it - so, I've added a note to the documentation to help others not run into the same mistake. :)
