### PR TITLE
Update typeahead_view.js

### DIFF
--- a/src/typeahead_view.js
+++ b/src/typeahead_view.js
@@ -25,7 +25,7 @@ var TypeaheadView = (function() {
         query: {
           position: 'relative',
           verticalAlign: 'top',
-          backgroundColor: 'transparent'
+          backgroundColor: '#fff'
         },
         dropdown: {
           position: 'absolute',


### PR DESCRIPTION
Remove the transparent background and set it to white (#fff) for the input.query, see: http://stackoverflow.com/questions/18167246/typeahead-problems-with-bootstrap-3-0-rc1/18171568 and http://stackoverflow.com/questions/18059161/css-issue-on-twitter-typeahead-with-bootstrap-3
