### PR TITLE
Allow overriding of ajax handler with custom objects (defaults to $.ajax)

### DIFF
--- a/src/transport.js
+++ b/src/transport.js
@@ -25,6 +25,7 @@ var Transport = (function() {
     this.wildcard = o.wildcard || '%QUERY';
     this.filter = o.filter;
     this.replace = o.replace;
+    this.ajaxHandler = o.ajaxHandler || $.ajax;
 
     this.ajaxSettings = {
       type: 'get',
@@ -75,7 +76,7 @@ var Transport = (function() {
       if (!jqXhr) {
         incrementPendingRequests();
         jqXhr = pendingRequests[url] =
-          $.ajax(url, this.ajaxSettings).always(always);
+          this.ajaxHandler(url, this.ajaxSettings).always(always);
       }
 
       return jqXhr;


### PR DESCRIPTION
In some settings, such as when a page is embedded within an iframe on another domain, a standard AJAX request isn't desirable as it could be blocked for breaking Same Origin Policy. This allows the user to override `remote.ajaxHandler` with their own handler which will 'do the right thing'.

This was written for an application which runs within a [Google Contextual Gadget](https://developers.google.com/gmail/contextual_gadgets), where cross-domain AJAX is blocked but a wrapper for proxying through Google is provided
