### PR TITLE
allow setting jsonp option for remote data

### DIFF
--- a/src/transport.js
+++ b/src/transport.js
@@ -31,7 +31,8 @@ var Transport = (function() {
       cache: o.cache,
       timeout: o.timeout,
       dataType: o.dataType || 'json',
-      beforeSend: o.beforeSend
+      beforeSend: o.beforeSend,
+      jsonp: o.jsonp
     };
 
     this._get = (/^throttle$/i.test(o.rateLimitFn) ?


### PR DESCRIPTION
Make typeahead.js work with Bing Maps API. See [my comment](https://github.com/twitter/typeahead.js/pull/25#issuecomment-22249409) and a short [example](http://plnkr.co/edit/jO2tGi?p=preview)
