### PR TITLE
Correct repo URL

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
     banner: [
       '/*!',
       ' * typeahead.js <%= version %>',
-      ' * https://github.com/twitter/typeahead',
+      ' * https://github.com/twitter/typeahead.js',
       ' * Copyright 2013 Twitter, Inc. and other contributors; Licensed MIT',
       ' */\n\n'
     ].join('\n'),


### PR DESCRIPTION
Corrected repository URL from https://github.com/twitter/typeahead to https://github.com/twitter/typeahead.js.
