### PR TITLE
Prevent sending of remote request if replace returns null

### DIFF
--- a/src/transport.js
+++ b/src/transport.js
@@ -106,6 +106,9 @@ var Transport = (function() {
       url = this.replace ?
         this.replace(this.url, encodedQuery) :
         this.url.replace(this.wildcard, encodedQuery);
+        
+      if (url == null)
+        return false;
 
       // in-memory cache hit
       if (resp = requestCache.get(url)) {

--- a/test/transport_spec.js
+++ b/test/transport_spec.js
@@ -91,6 +91,13 @@ describe('Transport', function() {
 
         expect(this.request.url).toEqual('http://example.com?q=$$has%20space');
       });
+      
+      it('should not send request when replace returns null', function() {
+        this.transport.replace = function(url, query) { return null; };
+        this.transport.get('has space');
+        this.request = mostRecentAjaxRequest();
+        expect(this.request).toBeNull();
+      });
 
       it('should piggyback off of pending requests', function() {
         this.spy1 = jasmine.createSpy();


### PR DESCRIPTION
Use case:  We have a typeahead field in which the url replacement pattern is
based on the value of another field. If that other field isn't set, we don't
want to allow the typeahead request to complete. This patch allows our replace
function to return null and prevent the request from being sent.
