### PR TITLE
Add dataset to 'suggestionsRendered' event

### DIFF
--- a/src/dropdown_view.js
+++ b/src/dropdown_view.js
@@ -254,7 +254,7 @@ var DropdownView = (function() {
         this.clearSuggestions(dataset.name);
       }
 
-      this.trigger('suggestionsRendered');
+      this.trigger('suggestionsRendered', dataset);
     },
 
     clearSuggestions: function(datasetName) {


### PR DESCRIPTION
As the title indicates, this PR adds the actual dataset being rendered to the 'suggestionsRendered' event.

This allows the clients to do post-rendering manipulation of suggestions depending on dataset being rendered. As typeahead support x number of datasets and y datasets being rendered in response to a query (important: y might be smaller than x), it's important to know to what this event might refer to.

A sample of post-rendering manipulation is a $compile process of angularjs or any other data-binding library.

Sample code client code with a customized typeahead.js library including this change can be found here:
https://github.com/geoadmin/mf-geoadmin3/blob/master/src/components/search/SearchDirective.js#L304
