### PR TITLE
Support jQuery 2

### DIFF
--- a/component.json
+++ b/component.json
@@ -5,6 +5,6 @@
     "dist/typeahead.js"
   ],
   "dependencies": {
-    "jquery": "~1.9"
+    "jquery": ">=1.9"
   }
 }

--- a/typeahead.js.jquery.json
+++ b/typeahead.js.jquery.json
@@ -5,7 +5,7 @@
     }
   ],
   "dependencies": {
-    "jquery": "~1.9"
+    "jquery": ">=1.9"
   },
   "docs": "https://github.com/twitter/typeahead.js",
   "demo": "http://twitter.github.com/typeahead.js/examples",


### PR DESCRIPTION
Typeahead.js seems to be working just fine on my website with jquery 2.0.3 and the README says "jQuery 1.9+" is required, so here is an update of the `component.json` file for bower.
