### PR TITLE
add oneSuggestionEvent

### DIFF
--- a/src/typeahead_view.js
+++ b/src/typeahead_view.js
@@ -161,6 +161,10 @@ var TypeaheadView = (function() {
 
         this.inputView.setHintValue(inputValue + (match ? match[1] : ''));
       }
+      var numSuggestions = this.dropdownView._getSuggestions().length;
+      if(numSuggestions == 1){
+        this.eventBus.trigger("oneSuggestionEvent", suggestion.datum, suggestion.dataset);
+      }
     },
 
     _clearHint: function() {


### PR DESCRIPTION
used in conjuction with repeat checking and setTimeout blur, enables
automatic selection.

pros: enables full auto-selection.
cons: uses private methods; does not handle multiple sources; event called on click as well as type complete; setTimeout( blur) needed to get rid of suggestion drop down.

```
typeahead
    .on('typeahead:selected',selected_action)
    .on('typeahead:autocompleted',selected_action)
    .on('typeahead:oneSuggestionEvent',selected_action);

 selected_action = function(event, datum){
    if(datum.value === ac){
      console.log("nothing changed, move along");
      return;
    }else{
      ac = datum.value;
    }
    jQuery('.type-ahead-example').typeahead('setQuery', datum.value);
    setTimeout(function(){
    jQuery('.type-ahead-example').blur();}, 0);

  // some ajax call

    jQuery('.some-other-field').focus();
  }
```
