### PR TITLE
Allow suggestions to show duplicate suggestions

### DIFF
--- a/src/dataset.js
+++ b/src/dataset.js
@@ -29,6 +29,7 @@ var Dataset = (function() {
     this.header = o.header;
     this.footer = o.footer;
     this.valueKey = o.valueKey || 'value';
+    this.showDuplicate = o.showDuplicate || false;
     this.template = compileTemplate(o.template, o.engine, this.valueKey);
 
     // used then deleted in #initialize
@@ -258,7 +259,6 @@ var Dataset = (function() {
 
       terms = utils.tokenizeQuery(query);
       suggestions = this._getLocalSuggestions(terms).slice(0, this.limit);
-
       if (suggestions.length < this.limit && this.transport) {
         cacheHit = this.transport.get(query, processRemoteData);
       }
@@ -277,7 +277,7 @@ var Dataset = (function() {
           var item = that._transformDatum(datum), isDuplicate;
 
           // checks for duplicates
-          isDuplicate = utils.some(suggestions, function(suggestion) {
+          isDuplicate = !that.showDuplicate && utils.some(suggestions, function(suggestion) {
             return item.value === suggestion.value;
           });
 

--- a/test/dataset_spec.js
+++ b/test/dataset_spec.js
@@ -461,6 +461,32 @@ describe('Dataset', function() {
     });
   });
 
+  describe('dataset can show duplicate with remote dataset', function() {
+    var spy = jasmine.createSpy(),
+        remote = ['grape', 'grape', 'grape'];
+
+    beforeEach(function() {
+      this.dataset = new Dataset({ remote: '/remote', showDuplicate: true });
+      this.dataset.initialize();
+    });
+
+    it('show duplicate suggestions if showDuplicate set to true in dataset', function() {
+      this.dataset.transport.get.andCallFake(function(q, cb) {
+        utils.defer(function() { cb(remote); });
+      });
+      this.dataset.getSuggestions('g', spy);
+      waitsFor(function() { return spy.callCount === 2; });
+      runs(function() {
+        //remote suggestions
+        expect(spy.argsForCall[1][0]).toEqual([
+          expectedItemHash.grape,
+          expectedItemHash.grape,
+          expectedItemHash.grape
+        ]);
+      });
+    });
+  });
+
   // helper functions
   // ----------------
 


### PR DESCRIPTION
Show suggestions duplicate by valueKey if showDuplicate is set to true during initialization
This is set to false by default.

$('input.typeahead-devs').typeahead({
  showDuplicate: true,
  ...
});
