### PR TITLE
jQuery addClass typo, classnames don't need '.'

### DIFF
--- a/test/dropdown_view_spec.js
+++ b/test/dropdown_view_spec.js
@@ -141,7 +141,7 @@ describe('DropdownView', function() {
 
         this.$menu
         .find('.tt-suggestions > .tt-suggestion')
-        .addClass('.tt-is-under-cursor');
+        .addClass('tt-is-under-cursor');
 
         // HACK: let's just assume this has been set to true
         this.dropdownView.isMouseOverDropdown = true;


### PR DESCRIPTION
Caught this typo, but the test actually passes with and
without this code change. I'm helping!!
