### PR TITLE
tt-hint should be switched to right along with RTL

### DIFF
--- a/dist/typeahead.js
+++ b/dist/typeahead.js
@@ -796,7 +796,13 @@
                     left: "auto",
                     right: " 0"
                 };
-                dir === "ltr" ? this.$menu.css(ltrCss) : this.$menu.css(rtlCss);
+                if (dir === "ltr") {
+                    this.$menu.css(ltrCss);
+                    this.$hint.css(ltrCss);
+                } else {
+                    this.$menu.css(rtlCss);
+                    this.$hint.css(rtlCss);
+                }
             },
             moveCursorUp: function() {
                 this._moveCursor(-1);


### PR DESCRIPTION
.tt-hint should be moved to the right when writing RTL languages as this only happens with .tt-dropdown-menu. This  scenario happens when searching for either RTL or LTR texts in the same input field. 
