### PR TITLE
Allow transport url to be a function

### DIFF
--- a/src/transport.js
+++ b/src/transport.js
@@ -13,7 +13,7 @@ var Transport = (function() {
   function Transport(o) {
     utils.bindAll(this);
 
-    o = utils.isString(o) ? { url: o } : o;
+    o = utils.isString(o) || utils.isFunction(o) ? { url: o } : o;
 
     requestCache = requestCache || new RequestCache();
 
@@ -99,13 +99,16 @@ var Transport = (function() {
       var that = this,
           encodedQuery = encodeURIComponent(query || ''),
           url,
-          resp;
+          resp,
+          baseUrl = this.url;
 
       cb = cb || utils.noop;
 
+      baseUrl = utils.isFunction(baseUrl) ? baseUrl.call() : baseUrl;
+
       url = this.replace ?
-        this.replace(this.url, encodedQuery) :
-        this.url.replace(this.wildcard, encodedQuery);
+        this.replace(baseUrl, encodedQuery) :
+        baseUrl.replace(this.wildcard, encodedQuery);
 
       // in-memory cache hit
       if (resp = requestCache.get(url)) {

--- a/test/transport_spec.js
+++ b/test/transport_spec.js
@@ -196,3 +196,42 @@ describe('Transport', function() {
     });
   });
 });
+
+describe('Transport function as url', function() {
+  var successData = { prop: 'val' },
+      successResp = { status: 200, responseText: JSON.stringify(successData) },
+      errorResp = { status: 500 },
+      _debounce;
+
+  beforeEach(function() {
+    jasmine.Ajax.useMock();
+    jasmine.RequestCache.useMock();
+
+    _debounce = utils.debounce;
+    utils.debounce = function(fn) { return fn; };
+
+    this.transport = new Transport({
+      url: function () { return 'http://example.com?q=$$'; },
+      wildcard: '$$',
+      debounce: true,
+      maxParallelRequests: 3
+    });
+
+    // request cache is hidden in transport's closure
+    // so this is how we access it to spy on its methods
+    this.requestCache = RequestCache.instance;
+    spyOn(this.requestCache, 'get');
+    spyOn(this.requestCache, 'set');
+  });
+
+  describe('#get', function() {
+    describe('when below pending requests threshold', function() {
+      it('should make remote request', function() {
+        this.transport.get('has space');
+        this.request = mostRecentAjaxRequest();
+
+        expect(this.request).not.toBeNull();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Allowing this we would be able to change the URL on the fly in order to
combine more fields to build a query url.

e.g.
I have two autocomplete fields, one is a state, and the other is a
document emitter, but my need is, when the user pick up a state, they
will only see emitters from that state. So the autocomplete call will
look like that:

```
$('#emitter').autocomplete({
   url: function () {
       var state = $("#state").val();

       return '/emitters?q=%QUERY&state=' + state;
   }
});
```

Each time before a request this function will be evaluated, generating
a new url for the request according to what was defined. The only
requirement is this function to return a string.
