### PR TITLE
Change jQuery to $ in function declaration

### DIFF
--- a/src/typeahead/plugin.js
+++ b/src/typeahead/plugin.js
@@ -107,7 +107,7 @@
     }
   };
 
-  jQuery.fn.typeahead = function(method) {
+  $.fn.typeahead = function(method) {
     if (methods[method]) {
       return methods[method].apply(this, [].slice.call(arguments, 1));
     }


### PR DESCRIPTION
When compiled for distribution, `window.jQuery` is passed in to the wrapper function, and is set to the variable `$` internally. We should maintain that variable when defining the typeahead function.

https://github.com/twitter/typeahead.js/blob/d5402b3b62c3659a9107c014ba56322ff17ab170/dist/typeahead.jquery.js#L1115

https://github.com/twitter/typeahead.js/blob/d5402b3b62c3659a9107c014ba56322ff17ab170/dist/typeahead.jquery.js#L7

Thanks!
