### PR TITLE
set cursor to top suggestion when autoselect is on

### DIFF
--- a/src/typeahead/dropdown.js
+++ b/src/typeahead/dropdown.js
@@ -129,6 +129,20 @@ var Dropdown = (function() {
       this._ensureVisible($newCursor);
     },
 
+    _moveCursorToTop: function moveCursorToTop() {
+      var $suggestion = this._getSuggestions().first();
+
+      if (!this.isOpen || !$suggestion) { return; }
+
+      this._removeCursor();
+
+      this._setCursor($suggestion, true);
+
+      // in the case of scrollable overflow
+      // make sure the cursor is visible in the menu
+      this._ensureVisible($suggestion);
+    },
+
     _ensureVisible: function ensureVisible($el) {
       var elTop, elBottom, menuScrollTop, menuHeight;
 
@@ -181,6 +195,10 @@ var Dropdown = (function() {
 
     moveCursorDown: function moveCursorDown() {
       this._moveCursor(+1);
+    },
+
+    moveCursorToTop: function moveCursorToTop() {
+      this._moveCursorToTop();
     },
 
     getDatumForSuggestion: function getDatumForSuggestion($el) {

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -96,6 +96,9 @@ var Typeahead = (function() {
 
     _onDatasetRendered: function onDatasetRendered() {
       this._updateHint();
+      if (this.autoselect) {
+        this.dropdown.moveCursorToTop();
+      }
     },
 
     _onOpened: function onOpened() {

--- a/test/dropdown_view_spec.js
+++ b/test/dropdown_view_spec.js
@@ -249,6 +249,40 @@ describe('Dropdown', function() {
     });
   });
 
+  describe('#moveCursorToTop', function() {
+    beforeEach(function() {
+      this.view.open();
+    });
+
+    it('should move the cursor to first suggestion', function() {
+      var $first;
+
+      $first = this.view._getSuggestions().first();
+
+      this.view.moveCursorToTop();
+      expect(this.view._getCursor()).toBe($first);
+    });
+
+    it('should not trigger cursorMoved', function() {
+      var spy;
+
+      this.view.onSync('cursorMoved', spy = jasmine.createSpy());
+      this.view.moveCursorToTop();
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should remove existing cursor', function() {
+      var $bottom;
+
+      $bottom = this.view._getSuggestions().eq(-1);
+      this.view._setCursor($bottom);
+      this.view.moveCursorToTop();
+
+      expect(this.view._getCursor().length).toBe(1);
+    });
+  });
+
   describe('#getDatumForSuggestion', function() {
     it('should extract the datum from the suggestion element', function() {
       var $suggestion, datum;


### PR DESCRIPTION
There is no visual feedback to the user if autoselect is turned on. This pull request will set the cursor to the top suggestion after the dataset has been rendered.
