### PR TITLE
Add dropdownShown and dropdownHidden events.

### DIFF
--- a/src/typeahead/dropdown.js
+++ b/src/typeahead/dropdown.js
@@ -72,12 +72,16 @@ var Dropdown = (function() {
 
     _hide: function() {
       this.$menu.hide();
+
+      this.trigger('dropdownHidden');
     },
 
     _show: function() {
       // can't use jQuery#show because $menu is a span element we want
       // display: block; not dislay: inline;
       this.$menu.css('display', 'block');
+
+      this.trigger('dropdownShown');
     },
 
     _getSuggestions: function getSuggestions() {

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -36,6 +36,8 @@ var Typeahead = (function() {
     .onSync('cursorRemoved', this._onCursorRemoved, this)
     .onSync('opened', this._onOpened, this)
     .onSync('closed', this._onClosed, this)
+    .onSync('dropdownShown', this._onDropdownShown, this)
+    .onSync('dropdownHidden', this._onDropdownHidden, this)
     .onAsync('datasetRendered', this._onDatasetRendered, this);
 
     this.input = new Input({ input: $input, hint: $hint })
@@ -108,6 +110,14 @@ var Typeahead = (function() {
       this.input.clearHint();
 
       this.eventBus.trigger('closed');
+    },
+
+    _onDropdownShown: function onDropdownShown() {
+      this.eventBus.trigger('dropdownShown');
+    },
+
+    _onDropdownHidden: function onDropdownHidden() {
+      this.eventBus.trigger('dropdownHidden');
     },
 
     _onFocused: function onFocused() {


### PR DESCRIPTION
They're a bit different with `opened` and `closed` events.
As I found, the `opened` and `closed` events are fired when the input gets the focus or not.
`dropdown...` events I implemented are fired when the dropdown element's `display` style is changed.

I used them to change the css of the input element, especially `border-radius` to flatten the border-bottom only when the dropdown is shown.
I think there may be others who want the feature, and I upload this pull request.

Thanks.
