### PR TITLE
Fixes for bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,7 @@
 {
   "name": "typeahead.js",
   "version": "0.10.1",
-  "main": [
-    "dist/bloodhound.js",
-    "dist/typeahead.jquery.js",
-    "dist/typeahead.bundle.js",
-    "dist/typeahead.bundle.min.js"
-  ],
+  "main": "dist/typeahead.bundle.js",
   "dependencies": {
     "jquery": ">=1.9"
   }


### PR DESCRIPTION
The "main" option of bower.json should include the paths to the library's endpoints (rather than just the filenames), as per the [Bower spec](https://github.com/bower/bower#defining-a-package). This allows tools like [Bower Installer](https://github.com/blittle/bower-installer) to move only the required distribution code into a project.

As well, typeahead should work with any jQuery version >=1.9, rather than ~1.9 (which restricts the rest of an app to using that version).
