### PR TITLE
Ability to use WebSocket as transport on prefetch

### DIFF
--- a/src/bloodhound/bloodhound.js
+++ b/src/bloodhound/bloodhound.js
@@ -68,7 +68,9 @@ var Bloodhound = window.Bloodhound = (function() {
       }
 
       else {
-        deferred = $.ajax(o.url, o.ajax).done(handlePrefetchResponse);
+        deferred = (o.transport) ?
+          callbackTransport(o.transport, o.url) :
+          $.ajax(o.url, o.ajax).done(handlePrefetchResponse);
       }
 
       return deferred;
@@ -81,6 +83,26 @@ var Bloodhound = window.Bloodhound = (function() {
 
         that._saveToStorage(that.index.serialize(), o.thumbprint, o.ttl);
       }
+
+      function callbackTransport(fn, url)  {
+        var deferred = $.Deferred();
+
+        fn(url, onSuccess, onError);
+
+        return deferred;
+
+        function onSuccess(resp) {
+          _.defer(function() {
+            handlePrefetchResponse(resp);
+            deferred.resolve(resp);
+          });
+        }
+
+        function onError(err) {
+          _.defer(function() { deferred.reject(err); });
+        }
+      }
+
     },
 
     _getFromRemote: function getFromRemote(query, cb) {


### PR DESCRIPTION
I need to use websocket on prefetch and remote.
I realize that you can use it in remote https://github.com/twitter/typeahead.js/issues/338, but not on prefetch.
With this you can use a custom transport on prefetch.
