### PR TITLE
Fix error installing with bower due not-found paths

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,10 +2,10 @@
   "name": "typeahead.js",
   "version": "0.10.1",
   "main": [
-    "bloodhound.js",
-    "typeahead.jquery.js",
-    "typeahead.bundle.js",
-    "typeahead.bundle.min.js"
+    "dist/bloodhound.js",
+    "dist/typeahead.jquery.js",
+    "dist/typeahead.bundle.js",
+    "dist/typeahead.bundle.min.js"
   ],
   "dependencies": {
     "jquery": "~1.9"


### PR DESCRIPTION
Installing typeahead.js on my symfony 2 project through bower throw this exception:

```
The required file "/path/to/my/assets/typeahead.js/bloodhound.js" could not be found.
Did you accidentally deleted the "components" directory?
```

Changing the `"main"` paths on the bower.json fixed it.
