### PR TITLE
Adding colons and periods in valid dataset names

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -188,7 +188,7 @@ var Dataset = (function() {
   }
 
   function isValidName(str) {
-    // dashes, underscores, letters, and numbers
-    return (/^[_a-zA-Z0-9-]+$/).test(str);
+    // dashes, underscores, colons, periods, letters, and numbers
+    return (/^[_a-zA-Z0-9-:.]+$/).test(str);
   }
 })();


### PR DESCRIPTION
I think it would be usefull for many others.
Using periods  beacause json notations on deep properties.
