### PR TITLE
Pass `query` to suggestion template

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -103,7 +103,7 @@ var Dataset = (function() {
         function getSuggestionNode(suggestion) {
           var $el, innerHtml, outerHtml;
 
-          innerHtml = that.templates.suggestion(suggestion);
+          innerHtml = that.templates.suggestion(suggestion, query);
           outerHtml = html.suggestion.replace('%BODY%', innerHtml);
           $el = $(outerHtml)
           .data(datasetKey, that.name)


### PR DESCRIPTION
I'm open to other ways of passing the query, should you prefer. It's currently included implicitly, as part of the parent scope, but could be passed into `getSuggestionNode` explicitly to, for clarity.

Useful for:
- Customizing suggestion based on query, e.g. to dig out the matched substring from a long string, to highlight.
- To make a 'fake' empty suggestion (until–if god wills it–the empty template becomes selectable): https://github.com/twitter/typeahead.js/issues/520#issuecomment-36548282
