### PR TITLE
Add exec:npm_publish target

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -145,6 +145,9 @@ module.exports = function(grunt) {
           'git checkout -',
           'rm -rf typeahead.js'
         ].join(' && ')
+      },
+      npm_publish: {
+        cmd: 'npm publish'
       }
     },
 
@@ -188,6 +191,7 @@ module.exports = function(grunt) {
       'exec:git_commit:' + version,
       'exec:git_tag:' + version,
       //'exec:git_push',
+      //'exec:npm_publish',
       'exec:publish_assets'
     ]);
   });


### PR DESCRIPTION
As per https://github.com/twitter/typeahead.js/issues/743

I assume you meant the `release` task. Also, since I saw that `exec:git_push` is commented out by default, I did the same for the `exec:npm_publish` command, just in case.
