### PR TITLE
Add main file path to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
   "scripts": {
     "test": "./node_modules/.bin/karma start --single-run --browsers PhantomJS"
   },
-  "version": "0.10.1"
+  "version": "0.10.1",
+  "main": "dist/typeahead.bundle.js"
 }


### PR DESCRIPTION
It looks like I/You forgot to add the path to the main file to package.json before publishing to npm.

Without it, requiring the module fails:

```
require('typeahead.js');
// Throws Error: Cannot find module 'typeahead.js'
```

This PR will fix this issue.
