### PR TITLE
Set opacity on hint input

### DIFF
--- a/src/typeahead/css.js
+++ b/src/typeahead/css.js
@@ -14,7 +14,8 @@ var css = {
     top: '0',
     left: '0',
     borderColor: 'transparent',
-    boxShadow: 'none'
+    boxShadow: 'none',
+    opacity: '1'
   },
   input: {
     position: 'relative',


### PR DESCRIPTION
iOS Safari will set disabled inputs to opacity: 0.4. In order for the
hint to be fully visible, the opacity needs to be set to 1.

This fixes #741.
