### PR TITLE
Add support for HTML5 data attributes

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -40,15 +40,25 @@ var Dataset = (function() {
   // --------------
 
   Dataset.extractDatasetName = function extractDatasetName(el) {
-    return $(el).data(datasetKey);
+    return Dataset._extractDataAttribute(el, datasetKey);
   };
 
-  Dataset.extractValue = function extractDatum(el) {
-    return $(el).data(valueKey);
+  Dataset.extractValue = function extractValue(el) {
+    return Dataset._extractDataAttribute(el, valueKey);
   };
 
   Dataset.extractDatum = function extractDatum(el) {
-    return $(el).data(datumKey);
+    return Dataset._extractDataAttribute(el, datumKey);
+  };
+
+  Dataset._extractDataAttribute = function extractDataAttribute(el, attribute) {
+    var dataAttribute = $(el).data(attribute);
+
+    if (dataAttribute === undefined) {
+      dataAttribute = $(el).data(attribute.toLowerCase());
+    }
+
+    return dataAttribute;
   };
 
   // instance methods

--- a/test/dropdown_view_spec.js
+++ b/test/dropdown_view_spec.js
@@ -259,6 +259,15 @@ describe('Dropdown', function() {
       expect(datum).toEqual({ value: 'one', raw: 'two' });
     });
 
+    it('should extract the datum from the suggestion element when using HTML5 data attributes', function() {
+      var $suggestion, datum;
+
+      $suggestion = $('<div data-ttValue="one" data-ttDatum="two">');
+      datum = this.view.getDatumForSuggestion($suggestion);
+
+      expect(datum).toEqual({ value: 'one', raw: 'two' });
+    });
+
     it('should return null if no element is given', function() {
       expect(this.view.getDatumForSuggestion($('notreal'))).toBeNull();
     });


### PR DESCRIPTION
Typeahead is unable to read HTML5 data attributes because of [this](http://www.w3.org/TR/html5/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes). The browser will automatically lowercase the attribute and therefore jQuery won't be able to find the following keys:
- ttValue
- ttDatum
- ttDataset
