### PR TITLE
Enable support for multiple source fields in the tokenizer

### DIFF
--- a/src/bloodhound/tokenizers.js
+++ b/src/bloodhound/tokenizers.js
@@ -21,7 +21,13 @@ var tokenizers = (function(root) {
 
   function getObjTokenizer(tokenizer) {
     return function setKey(key) {
-      return function tokenize(o) { return tokenizer(o[key]); };
+      return function tokenize(o) {
+        var rtval = [];
+        _.each(tokenizer(key), function(k) { 
+          if (o[k]) rtval = rtval.concat(tokenizer(o[k]));
+          });
+        return rtval;
+      };
     };
   }
 })();


### PR DESCRIPTION
Allow multiple source fields, separated by space:

Before:
datumTokenizer: Bloodhound.tokenizers.obj.whitespace('name'),

After:
datumTokenizer: Bloodhound.tokenizers.obj.whitespace('name description'),
