### PR TITLE
Implement character triggers (@-mentions)

### DIFF
--- a/src/typeahead/plugin.js
+++ b/src/typeahead/plugin.js
@@ -36,6 +36,8 @@
           withHint: _.isUndefined(o.hint) ? true : !!o.hint,
           minLength: o.minLength,
           autoselect: o.autoselect,
+          triggerCharacter: o.triggerCharacter,
+          triggerRegex: o.triggerRegex,
           datasets: datasets
         });
 

--- a/test/input_view_trigger_spec.js
+++ b/test/input_view_trigger_spec.js
@@ -1,0 +1,285 @@
+describe('Input with character triggers', function() {
+  var KEYS;
+
+   KEYS = {
+    enter: 13,
+    esc: 27,
+    tab: 9,
+    left: 37,
+    right: 39,
+    up: 38,
+    down: 40,
+    normal: 65 // "A" key
+  };
+
+  beforeEach(function() {
+    var $fixture;
+
+    var atMentionsChar = '@';
+    var atMentionsRegex = '\\w*';
+    var triggerRegex = new RegExp(atMentionsChar + atMentionsRegex, 'g');
+
+    setFixtures(fixtures.html.input + fixtures.html.hint);
+
+    $fixture = $('#jasmine-fixtures');
+    this.$input = $fixture.find('.tt-input');
+    this.$hint = $fixture.find('.tt-hint');
+
+    this.view = new Input({ input: this.$input, hint: this.$hint, triggerCharacter: atMentionsChar, triggerRegex: triggerRegex });
+  });
+
+  it('should throw an error if no hint and/or input is provided', function() {
+    expect(noInput).toThrow();
+
+    function noInput() { new Input({ hint: '.hint' }); }
+  });
+
+  describe('when the blur DOM event is triggered', function() {
+    it('should not reset the input value', function() {
+      this.view.setQuery('wine');
+      this.view.setInputValue('cheese', true);
+
+      this.$input.blur();
+
+      expect(this.$input.val()).toBe('cheese');
+    });
+  });
+
+  describe('when the keydown DOM event is triggered by left', function() {
+    it('should trigger queryChanged if the the cursor enters the trigger regex match', function() {
+      var spy;
+
+      this.view.$input.val('Hey there @cheesehead how are you?');
+      setCursorPosition(this.view.$input, 22);
+
+      this.view.setQuery('');
+      this.view.onSync('queryChanged', spy = jasmine.createSpy());
+
+      moveCursor(this.view, this.$input, 'left');
+      moveCursor(this.view, this.$input, 'left');
+
+      waitsFor(function() { return spy.callCount === 1; });
+    });
+
+    it('should trigger queryChanged if the the cursor does not enter the trigger regex match', function() {
+      this.view.$input.val('Hey there @cheesehead how are you?');
+      setCursorPosition(this.view.$input, 29);
+
+      this.view.setQuery('');
+      this.view.onSync('queryChanged', spy = jasmine.createSpy());
+
+      moveCursor(this.view, this.$input, 'left');
+      moveCursor(this.view, this.$input, 'left');
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the keydown DOM event is triggered by right', function() {
+    it('should trigger queryChanged if the the cursor enters the trigger regex match', function() {
+      var spy;
+
+      this.view.$input.val('Hey there @cheesehead how are you?');
+      setCursorPosition(this.view.$input, 9);
+
+      this.view.setQuery('');
+      this.view.onSync('queryChanged', spy = jasmine.createSpy());
+
+      moveCursor(this.view, this.$input, 'right');
+      moveCursor(this.view, this.$input, 'right');
+      moveCursor(this.view, this.$input, 'right');
+
+      waitsFor(function() { return spy.callCount === 1; });
+    });
+
+    it('should trigger queryChanged if the the cursor does not enter the trigger regex match', function() {
+      this.view.$input.val('Hey there @cheesehead how are you?');
+      setCursorPosition(this.view.$input, 29);
+
+      this.view.setQuery('');
+      this.view.onSync('queryChanged', spy = jasmine.createSpy());
+
+      moveCursor(this.view, this.$input, 'right');
+      moveCursor(this.view, this.$input, 'right');
+      moveCursor(this.view, this.$input, 'right');
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  // NOTE: have to treat these as async because the ie polyfill acts
+  // in a async manner
+  describe('when the input DOM event is triggered', function() {
+    it('should not update query if it doesnt include a trigger', function() {
+      this.view.setQuery('wine');
+      this.view.setInputValue('cheese', true);
+
+      expect(this.view.getInputValue()).toBe('cheese');
+    });
+
+    it('should update query if it includes a trigger', function() {
+      this.view.setQuery('wine');
+      this.view.setInputValue('I love @cheese', true);
+
+      simulateInputEvent(this.$input);
+
+      waitsFor(function() { return this.view.getQuery() === 'cheese'; });
+    });
+
+    it('should not trigger queryChanged if the input value does not include a trigger', function() {
+      var spy;
+
+      this.view.setQuery('');
+      this.view.setInputValue('cheese', true);
+      this.view.onSync('queryChanged', spy = jasmine.createSpy());
+
+      simulateInputEvent(this.$input);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should trigger queryChanged if the input value does include a trigger', function() {
+      var spy;
+
+      this.view.setQuery('wine');
+      this.view.setInputValue('@cheese', true);
+      this.view.onSync('queryChanged', spy = jasmine.createSpy());
+
+      simulateInputEvent(this.$input);
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('should not trigger whitespaceChagned if input value does not include a trigger', function() {
+      var spy;
+
+      this.view.setQuery('wine  bar');
+      this.view.setInputValue('wine bar', true);
+      this.view.onSync('whitespaceChanged', spy = jasmine.createSpy());
+
+      simulateInputEvent(this.$input);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should trigger whitespaceChagned if input value does include a trigger', function() {
+      var spy;
+
+      this.view.triggerRegex = /@\w+\s?\w*/g;
+
+      this.view.setQuery('wine  bar');
+      this.view.setInputValue('@wine bar', true);
+      this.view.onSync('whitespaceChanged', spy = jasmine.createSpy());
+
+      simulateInputEvent(this.$input);
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('#setInputValue', function() {
+    it('should act as setter to the input value', function() {
+      this.view.setInputValue('cheese');
+      expect(this.view.getInputValue()).toBe('cheese');
+    });
+
+    it('should act as setter to the input value with a trigger and set cursor position', function() {
+      this.view.setInputValue('@cheese');
+      expect(this.view.getInputValue()).toBe('@cheese');
+      expect(this.view._getCursorPosition()).toBe('@cheese'.length);
+    });
+
+    it('should properly set input with a cursor position and trigger', function() {
+      this.view.$input.val('Hey there @ how are you?');
+      setCursorPosition(this.view.$input, 11);
+      this.view.setInputValue('cheesehead');
+
+      expect(this.view.getInputValue()).toBe('Hey there @cheesehead how are you?');
+      expect(this.view._getCursorPosition()).toBe(21);
+    });
+
+    it('should trigger {query|whitespace}Changed when applicable', function() {
+      var spy1, spy2;
+
+      this.view.triggerRegex = /@\w+\s*\w*/g;
+
+      this.view.onSync('queryChanged', spy1 = jasmine.createSpy());
+      this.view.onSync('whitespaceChanged', spy2 = jasmine.createSpy());
+
+      this.view.setInputValue('go @cheese head');
+      expect(spy1).toHaveBeenCalled();
+      expect(spy2).not.toHaveBeenCalled();
+
+      this.view.setInputValue('go @cheese  head');
+      expect(spy1.callCount).toBe(1);
+      expect(spy2).toHaveBeenCalled();
+    });
+  });
+
+  describe('#resetInputValue', function() {
+    it('should not reset input value to last query if a trigger is present', function() {
+      this.view.setQuery('cheese');
+      this.view.setInputValue('cheese and @wine', true);
+
+      this.view.resetInputValue();
+      expect(this.view.getInputValue()).toBe('cheese and @wine');
+    });
+  });
+
+  // helper functions
+  // ----------------
+
+  function simulateInputEvent($node) {
+    var $e, type;
+
+    type = _.isMsie() ? 'keypress' : 'input';
+    $e = $.Event(type);
+
+    $node.trigger($e);
+  }
+
+  function moveCursor(ctx, $node, rightOrLeft) {
+    var cursorPosition, key;
+
+    key = rightOrLeft === 'left' ? KEYS.left : KEYS.right;
+    simulateKeyEvent($node, 'keydown', key);
+
+    cursorPosition = ctx._getCursorPosition();
+    rightOrLeft === 'left' ? cursorPosition-- : cursorPosition++;
+    setCursorPosition($node, cursorPosition);
+  }
+
+  function simulateKeyEvent($node, type, key, withModifier) {
+    var $e;
+
+    $e = $.Event(type, {
+      keyCode: key,
+      altKey: !!withModifier,
+      ctrlKey: !!withModifier,
+      metaKey: !!withModifier,
+      shiftKey: !!withModifier
+    });
+
+    spyOn($e, 'preventDefault');
+    $node.trigger($e);
+
+    return $e;
+  }
+
+  function setCursorPosition($input, pos) {
+    var input = $input[0], range;
+
+    if (input.setSelectionRange) {
+      input.focus();
+      input.setSelectionRange(pos, pos);
+    }
+
+    else if (input.createTextRange) {
+      range = input.createTextRange();
+      range.collapse(true);
+      range.moveEnd('character', pos);
+      range.moveStart('character', pos);
+      range.select();
+    }
+  }
+});

--- a/test/playground.html
+++ b/test/playground.html
@@ -59,6 +59,15 @@
       <div class="typeahead-wrapper">
         <input class="mixed" type="text" placeholder="mixed">
       </div>
+      <div class="typeahead-wrapper">
+        <input class="at-mentions" type="text" placeholder="@username">
+      </div>
+      <div class="typeahead-wrapper">
+        <textarea class="at-mentions" placeholder="@username"></textarea>
+      </div>
+      <div class="typeahead-wrapper">
+        <textarea class="name-mentions" placeholder="@First Last"></textarea>
+      </div>
     </div>
     </div>
 
@@ -300,6 +309,61 @@
         source: mixed.ttAdapter()
       });
 
+      var atMentions = new Bloodhound({
+        datumTokenizer: function(d) {
+          return Bloodhound.tokenizers.whitespace(d.val);
+        },
+        queryTokenizer: Bloodhound.tokenizers.whitespace,
+        local: [
+          { val: 'Mike' },
+          { val: 'Luke' },
+          { val: 'Jake' }
+        ]
+      });
+
+      atMentions.initialize();
+
+      var atMentionsChar = '@';
+      var atMentionsRegex = '\\w*';
+      var queryRegex = new RegExp(atMentionsChar + atMentionsRegex, 'g');
+      $('.at-mentions').typeahead({
+        highlight: true,
+        triggerRegex: queryRegex,
+        triggerCharacter: atMentionsChar
+      },
+      {
+        displayKey: 'val',
+        source: atMentions.ttAdapter()
+      });
+
+      var nameMentions = new Bloodhound({
+        datumTokenizer: function(d) {
+          return d.val;
+        },
+        queryTokenizer: function (s) {
+          return s;
+        },
+        local: [
+          { val: 'Mike Jones' },
+          { val: 'Luke Karrys' },
+          { val: 'Jake Harding' }
+        ]
+      });
+
+      nameMentions.initialize();
+
+      var nameMentionsChar = '@';
+      var nameMentionsRegexStr = '\\w+\\s?\\w*';
+      var nameMentioinsRegex = new RegExp(nameMentionsChar + nameMentionsRegexStr, 'g');
+      $('.name-mentions').typeahead({
+        highlight: true,
+        triggerRegex: nameMentioinsRegex,
+        triggerCharacter: nameMentionsChar
+      },
+      {
+        displayKey: 'val',
+        source: nameMentions.ttAdapter()
+      });
 
       $('input').on([
         'typeahead:initialized',


### PR DESCRIPTION
This is basically #624 but adapted to work on the lastest master.

#### Syntax

```js
$('.at-mentions').typeahead({
  triggerRegex: /@\w*/g,
  triggerCharacter: '@'
 }, dataset);
```

#### Playground
- Added an input and textarea for @-mentions
- Added a textarea for name mentions, to show whitespace examples

#### Tests
There is also a new test file `input_view_trigger_spec.js`. It's largely based on `input_view_spec.js` but any tests that triggers don't affect were removed and any other tests were updated for the specific trigger use cases.

All tests pass, and I think the code coverage is pretty high, but I wasn't sure how to find that number specifically.

The only thing I'm not satisfied with as far as tests go is `typeahead.js#_updateHint`. I couldn't find that particular method tested anywhere else, so I wasn't sure exactly how to test it. I'm open to suggestions for that.

#### Per Dataset

I played around with using `queryTokenizer` to parse triggered items from the query, but ultimately decided that the code needed to be a part of `input.js` since there could be multiple queries in one input and which one is used is based on the cursor position.

This means that `triggerRegex` and `triggerCharacter` are top level properties. The other open issue about this was #339 and it asked for a different trigger character per dataset. This PR doesn't do that, but I believe `queryTokenizer` could get you pretty far if you wanted to parse the query differently for different datasets.

#### Other Notes
- Blur events will no longer reset the input to the last query since a query might only be a part of the input value
- Hints work if the query is at the very end of the input value. But if there is non-query text after the query, no hint will be displayed.
- left/right keys run `input.js#_checkInputValue` since a change in cursor position could change the query

