### PR TITLE
Allow the search index class to be provided by the user in `index`.

### DIFF
--- a/src/bloodhound/bloodhound.js
+++ b/src/bloodhound/bloodhound.js
@@ -33,7 +33,7 @@
       (this.prefetch.cacheKey || this.prefetch.url) : null;
 
     // the backing data structure used for fast pattern matching
-    this.index = new SearchIndex({
+    this.index = new (o.index || SearchIndex)({
       datumTokenizer: o.datumTokenizer,
       queryTokenizer: o.queryTokenizer
     });


### PR DESCRIPTION
Defaults to SearchIndex otherwise.

Could be a very simple fix for #96.

(If this kind of change is desirable I'll be more than happy to supplement it with documentation updates.)
