### PR TITLE
Allow customize the style of typeahead highlight text using 'tt-highlight' class.

### DIFF
--- a/doc/jquery_typeahead.md
+++ b/doc/jquery_typeahead.md
@@ -247,8 +247,8 @@ jQuery.fn._typeahead = typeahead;
 When initializing a typeahead, there are a number of options you can configure.
 
 * `highlight` – If `true`, when suggestions are rendered, pattern matches
-  for the current query in text nodes will be wrapped in a `strong` element. 
-  Defaults to `false`.
+  for the current query in text nodes will be wrapped in a `strong` element with
+  `tt-highlight` class. Defaults to `false`.
 
 * `hint` – If `false`, the typeahead will not show a hint. Defaults to `true`.
 

--- a/src/typeahead/highlight.js
+++ b/src/typeahead/highlight.js
@@ -12,7 +12,7 @@ var highlight = (function(doc) {
         node: null,
         pattern: null,
         tagName: 'strong',
-        className: null,
+        className: 'tt-highlight',
         wordsOnly: false,
         caseSensitive: false
       };


### PR DESCRIPTION
This would be very helpful if you want to render the highlighted text using different color.
