### PR TITLE
clarify Bloodhound's default suggestion limit

### DIFF
--- a/doc/bloodhound.md
+++ b/doc/bloodhound.md
@@ -159,7 +159,7 @@ options you can configure.
 
 * `limit` – The max number of suggestions to return from `Bloodhound#get`. If 
   not reached, the data source will attempt to backfill the suggestions from 
-  `remote`.
+  `remote`. If not set, the default is 5.
 
 * `dupDetector` – If set, this is expected to be a function with the signature 
   `(remoteMatch, localMatch)` that returns `true` if the datums are duplicates or 


### PR DESCRIPTION
Poked around the source to find why I was only seeing 5 results, thought this could use calling in the Docs
