### PR TITLE
Allow typeahead bower install to succeed against jquery 2+

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "0.10.3",
   "main": "dist/typeahead.bundle.js",
   "dependencies": {
-    "jquery": "~1.7"
+    "jquery": ">=1.7"
   },
   "devDependencies": {
     "jasmine-ajax": "~1.3.1",


### PR DESCRIPTION
I don't see anything in typeahead that prevents its use on higher versions of jQuery.
