### PR TITLE
`setInputValue` should trigger "change" event

### DIFF
--- a/src/typeahead/input.js
+++ b/src/typeahead/input.js
@@ -198,6 +198,7 @@ var Input = (function() {
 
     setInputValue: function setInputValue(value, silent) {
       this.$input.val(value);
+      this.$input.trigger('change');
 
       // silent prevents any additional events from being triggered
       silent ? this.clearHint() : this._checkInputValue();

--- a/test/input_view_spec.js
+++ b/test/input_view_spec.js
@@ -257,6 +257,13 @@ describe('Input', function() {
       expect(this.view.getInputValue()).toBe('cheese');
     });
 
+    it('should trigger the "change" event on the input', function() {
+      var spy;
+      this.$input.on('change', spy = jasmine.createSpy());
+      this.view.setInputValue('sandwiches');
+      expect(spy).toHaveBeenCalled();
+    });
+
     it('should trigger {query|whitespace}Changed when applicable', function() {
       var spy1, spy2;
 


### PR DESCRIPTION
When setting a new value on the input element, typeahead should trigger the "change" event on that element so that other components of an application can respond to the updated state.

---

Here's the use case that brought this to my attention. I'm working on something that asks people to type a CSS color name into an input field. The value of the input is checked on "keyup" and "change" events and if the input has a valid color, the background of the page is changed to that color.

This is a teaching tool for beginners, so typeahead suggestions are given, populated by the list of valid CSS colors. In testing I found that if an entry from the list of suggestions is clicked, the background would not change because while a new value was being set on the input, the "change" event never fires.
