### PR TITLE
Relax requirement on jQuery version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,10 +3,11 @@
   "version": "0.10.4",
   "main": "dist/typeahead.bundle.js",
   "dependencies": {
-    "jquery": "~1.7"
+    "jquery": ">=1.7"
   },
   "devDependencies": {
     "jasmine-ajax": "~1.3.1",
-    "jasmine-jquery": "~1.5.2"
+    "jasmine-jquery": "~1.5.2",
+    "jquery-1.7": "jquery#~1.7"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,7 +11,7 @@ preprocessors = {
 
 // list of files / patterns to load in the browser
 files = [
-  'bower_components/jquery/jquery.js',
+  'bower_components/jquery-1.7/jquery.js',
   'src/common/utils.js',
   'src/bloodhound/version.js',
   'src/bloodhound/tokenizers.js',

--- a/test/playground.html
+++ b/test/playground.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="../bower_components/jquery/jquery.js"></script>
+    <script src="../bower_components/jquery-1.7/jquery.js"></script>
     <script src="../dist/typeahead.bundle.js"></script>
 
     <style>


### PR DESCRIPTION
Fetch a separate copy of jQuery for use in development. The version of
this internal copy can be restricted to any value without effecting the
package resolution in downstream projects.
