### PR TITLE
Preempt JSON.parse(null) bug in older browsers

### DIFF
--- a/src/bloodhound/persistent_storage.js
+++ b/src/bloodhound/persistent_storage.js
@@ -126,6 +126,6 @@ var PersistentStorage = (function() {
   }
 
   function decode(val) {
-    return JSON.parse(val);
+    return (val===null) ? null : JSON.parse(val);
   }
 })();


### PR DESCRIPTION
In older browsers like that of Android 2.3.6, when JSON.parse() is passed a null value, it throws  "JSON.parse error illegal access" and breaks the flow of the code. This simple fix prevents that scenario.
