### PR TITLE
Events can fire on when Typeahead has been destroyed

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -23,6 +23,7 @@ var Typeahead = (function() {
     }
 
     this.isActivated = false;
+    this.isDestroyed = false;
     this.autoselect = !!o.autoselect;
     this.minLength = _.isNumber(o.minLength) ? o.minLength : 1;
     this.$node = buildDom(o.input, o.withHint);
@@ -88,6 +89,11 @@ var Typeahead = (function() {
     // ### private
 
     _onSuggestionClicked: function onSuggestionClicked(type, $el) {
+
+      if (this.isDestroyed) {
+        return;
+      }
+
       var datum;
 
       if (datum = this.dropdown.getDatumForSuggestion($el)) {
@@ -96,6 +102,11 @@ var Typeahead = (function() {
     },
 
     _onCursorMoved: function onCursorMoved() {
+
+      if (this.isDestroyed) {
+        return;
+      }
+
       var datum = this.dropdown.getDatumForCursor();
 
       this.input.setInputValue(datum.value, true);
@@ -104,21 +115,41 @@ var Typeahead = (function() {
     },
 
     _onCursorRemoved: function onCursorRemoved() {
+
+      if (this.isDestroyed) {
+        return;
+      }
+
       this.input.resetInputValue();
       this._updateHint();
     },
 
     _onDatasetRendered: function onDatasetRendered() {
+
+      if (this.isDestroyed) {
+        return;
+      }
+
       this._updateHint();
     },
 
     _onOpened: function onOpened() {
+
+      if (this.isDestroyed) {
+        return;
+      }
+
       this._updateHint();
 
       this.eventBus.trigger('opened');
     },
 
     _onClosed: function onClosed() {
+
+      if (this.isDestroyed) {
+        return;
+      }
+
       this.input.clearHint();
 
       this.eventBus.trigger('closed');
@@ -313,6 +344,7 @@ var Typeahead = (function() {
       destroyDomStructure(this.$node);
 
       this.$node = null;
+      this.isDestroyed = true;
     }
   });
 


### PR DESCRIPTION
This is a tricky to reproduce bug in the same ballpark as https://github.com/twitter/typeahead.js/issues/970 but the code here doesn't resolve that.

We've only experienced it on Android Chrome and iOS Safari (both tested on latest releases), we have a view in a web app with multiple typeahead inputs on and when the view is closed the error fires if we have focus on a field. So what happens in an instance is the input is blurred, potentially changed, typeahead is destroyed and the parent element for it is removed from the DOM. 

This is a stack trace:

	TypeError: 'null' is not an object (evaluating 'this.$menu.find')
	getSuggestions (manifest_footer.js, line 75418)
	getDatumForTopSuggestion (manifest_footer.js, line 75500)
	updateHint (manifest_footer.js, line 75693)
	onDatasetRendered (manifest_footer.js, line 75607)
	onDatasetRendered
	flush (manifest_footer.js, line 74963)
	(anonymous function) (manifest_footer.js, line 74979)

I'm assuming it's related to https://github.com/twitter/typeahead.js/blob/master/src/typeahead/event_emitter.js#L104 which delays the event so it runs after destroy has run.
