### PR TITLE
Add AMD (asynchronous module definition) support

### DIFF
--- a/dist/typeahead.jquery.js
+++ b/dist/typeahead.jquery.js
@@ -4,7 +4,17 @@
  * Copyright 2013-2014 Twitter, Inc. and other contributors; Licensed MIT
  */
 
-(function($) {
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(['jquery'], function ($) {
+            factory($, root);
+        });
+    } else {
+        // Browser globals
+        factory(jQuery, root);
+    }
+}(this, function(jQuery, window) {
     var _ = function() {
         "use strict";
         return {
@@ -1181,4 +1191,5 @@
             return this;
         };
     })();
-})(window.jQuery);
+    return {};
+}));

--- a/dist/typeahead.jquery.js
+++ b/dist/typeahead.jquery.js
@@ -14,7 +14,7 @@
         // Browser globals
         factory(jQuery, root);
     }
-}(this, function(jQuery, window) {
+}(this, function($, window) {
     var _ = function() {
         "use strict";
         return {


### PR DESCRIPTION
Add support for [AMD](https://github.com/amdjs/amdjs-api/wiki/AMD), used by module loaders such as require.js (with fallback mode if a module loader is not present).

Boilerplate code taken from [UMD patterns repo](https://github.com/umdjs/umd)