### PR TITLE
Fix compatibility with fastclick

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -126,12 +126,12 @@ var Typeahead = (function() {
 
     _onFocused: function onFocused() {
       this.isActivated = true;
+      this.dropdown.empty();
       this.dropdown.open();
     },
 
     _onBlurred: function onBlurred() {
       this.isActivated = false;
-      this.dropdown.empty();
       this.dropdown.close();
     },
 

--- a/test/typeahead_view_spec.js
+++ b/test/typeahead_view_spec.js
@@ -157,6 +157,12 @@ describe('Typeahead', function() {
       expect(this.view.isActivated).toBe(true);
     });
 
+    it('should empty the dropdown', function() {
+      this.input.trigger('focused');
+
+      expect(this.dropdown.empty).toHaveBeenCalled();
+    });
+
     it('should open the dropdown', function() {
       this.input.trigger('focused');
 
@@ -169,12 +175,6 @@ describe('Typeahead', function() {
       this.input.trigger('blurred');
 
       expect(this.view.isActivated).toBe(false);
-    });
-
-    it('should empty the dropdown', function() {
-      this.input.trigger('blurred');
-
-      expect(this.dropdown.empty).toHaveBeenCalled();
     });
 
     it('should close the dropdown', function() {


### PR DESCRIPTION
Emptying the dropdown on blur instead of on focus in d20dcfc somehow broke compatibility with fastclick.

I don't know what other implications changing this back may have. The only description for the original change was "Update typeahead plugin to adhere to new UI spec." but I'm not sure were to find that spec. @jharding, could you shine a light on this?

Fixes #792.