### PR TITLE
Fix nonsecure content warning in IE7 with HTTPS

### DIFF
--- a/src/typeahead/css.js
+++ b/src/typeahead/css.js
@@ -60,9 +60,10 @@ var css = (function() {
   // ie specific styling
   if (_.isMsie()) {
      // ie6-8 (and 9?) doesn't fire hover and click events for elements with
-     // transparent backgrounds, for a workaround, use 1x1 transparent gif
+     // transparent backgrounds, for a workaround, use a background image.
+     // To avoid security warnings in IE7, use about:blank as the image url.
     _.mixin(css.input, {
-      backgroundImage: 'url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7)'
+      backgroundImage: 'url(about:blank)'
     });
   }
 


### PR DESCRIPTION
typeahead.js causes a mixed content security warning in IE7 via HTTPS due to the use of a data url to add a background image (IE7 does not support data urls).

Replacing the data url with about:blank appears to work fine, which I did after reading some background info on a similar workaround in jqueryui. See jqueryui bug #7233 for some background info.

Automated tests are passing after this change, and I've manually tested in IE7, 8 and 9. Having said that, my css and js skills are very rusty, so some further testing wouldn't hurt :-)

Other browsers should not be affected as this in an IE specific workaround.