### PR TITLE
Adding option to preserve default tab behaviour

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -24,6 +24,7 @@ var Typeahead = (function() {
 
     this.isActivated = false;
     this.autoselect = !!o.autoselect;
+    this.defaultOnTab = !!o.defaultOnTab;
     this.minLength = _.isNumber(o.minLength) ? o.minLength : 1;
     this.$node = buildDom(o.input, o.withHint);
 
@@ -157,7 +158,8 @@ var Typeahead = (function() {
 
       if (datum = this.dropdown.getDatumForCursor()) {
         this._select(datum);
-        $e.preventDefault();
+
+        if(!this.defaultOnTab) { $e.preventDefault(); }
       }
 
       else {

--- a/test/typeahead_view_spec.js
+++ b/test/typeahead_view_spec.js
@@ -243,6 +243,18 @@ describe('Typeahead', function() {
 
         expect($e.preventDefault).toHaveBeenCalled();
       });
+
+      describe('when defaultOnTab is true', function() {
+        it('should not prevent the default behavior of the event', function() {
+          var $e;
+          this.view.defaultOnTab = true;
+
+          $e = jasmine.createSpyObj('event', ['preventDefault']);
+          this.input.trigger('tabKeyed', $e);
+
+          expect($e.preventDefault).not.toHaveBeenCalled();
+        });
+      });
     });
 
     describe('when cursor is not in use', function() {


### PR DESCRIPTION
In cases where a typeahead component is part of a larger form, I have added the option to preserve default browser 'on tab' behaviour which will select the highlighted suggestion whilst applying focus to the next field.