### PR TITLE
Added "blurred" event accessible to implementers

### DIFF
--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -133,6 +133,7 @@ var Typeahead = (function() {
       this.isActivated = false;
       this.dropdown.empty();
       this.dropdown.close();
+      this.eventBus.trigger("blurred");
     },
 
     _onEnterKeyed: function onEnterKeyed(type, $e) {

--- a/test/typeahead_view_spec.js
+++ b/test/typeahead_view_spec.js
@@ -182,6 +182,15 @@ describe('Typeahead', function() {
 
       expect(this.dropdown.close).toHaveBeenCalled();
     });
+    it('should trigger typeahead:blurred', function() {
+      var spy;
+
+      this.$input.on('typeahead:blurred', spy = jasmine.createSpy());
+
+      this.input.trigger('blurred');
+
+      expect(spy).toHaveBeenCalled();
+    });
   });
 
   describe('when input triggers enterKeyed', function() {


### PR DESCRIPTION
I use typeahead in conjunction with tagsManager (http://welldonethings.com/tags/manager). I use on('typeahead:selected') to add a completed tag to the tag set. The desired result is that tagsManager should create a new tag, and the user should have a blank entry box.
The problem is that if you immediately click away after finishing one entry, the blur event sets the new entry box to the text of the latest entry, rather than leaving it blank.
The least intrusive fix I could come up with is to expose the "typeahead:blurred" event via the api.