### PR TITLE
Adding basic WAI-ARIA support (Issue #397)

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -89,7 +89,9 @@ var Dataset = (function() {
       }
 
       function getSuggestionsHtml() {
-        var $suggestions, nodes;
+        var $suggestions, nodes, listboxId;
+        
+        listboxId = that.$el.parent().attr('id') + '-';
 
         $suggestions = $(html.suggestions).css(css.suggestions);
 
@@ -106,14 +108,15 @@ var Dataset = (function() {
 
         return $suggestions;
 
-        function getSuggestionNode(suggestion) {
+        function getSuggestionNode(suggestion, i) {
           var $el;
 
           $el = $(html.suggestion)
           .append(that.templates.suggestion(suggestion))
           .data(datasetKey, that.name)
           .data(valueKey, that.displayFn(suggestion))
-          .data(datumKey, suggestion);
+          .data(datumKey, suggestion)
+          .attr('id', listboxId + i);
 
           $el.children().each(function() { $(this).css(css.suggestionChild); });
 

--- a/src/typeahead/dropdown.js
+++ b/src/typeahead/dropdown.js
@@ -191,7 +191,8 @@ var Dropdown = (function() {
         datum = {
           raw: Dataset.extractDatum($el),
           value: Dataset.extractValue($el),
-          datasetName: Dataset.extractDatasetName($el)
+          datasetName: Dataset.extractDatasetName($el),
+          id: $el.attr('id')
         };
       }
 

--- a/src/typeahead/html.js
+++ b/src/typeahead/html.js
@@ -7,9 +7,9 @@
 var html = (function() {
   return {
     wrapper: '<span class="twitter-typeahead"></span>',
-    dropdown: '<span class="tt-dropdown-menu"></span>',
-    dataset: '<div class="tt-dataset-%CLASS%"></div>',
-    suggestions: '<span class="tt-suggestions"></span>',
-    suggestion: '<div class="tt-suggestion"></div>'
+    dropdown: '<span class="tt-dropdown-menu" role="listbox"></span>',
+    dataset: '<div class="tt-dataset-%CLASS%" role="presentation"></div>',
+    suggestions: '<span class="tt-suggestions" role="presentation"></span>',
+    suggestion: '<div class="tt-suggestion" role="option"></div>'
   };
 })();

--- a/src/typeahead/input.js
+++ b/src/typeahead/input.js
@@ -229,6 +229,26 @@ var Input = (function() {
 
       !isValid && this.clearHint();
     },
+    
+    setAriaActivedescendant: function setAriaActivedescendant(id) {
+      this.$input.attr('aria-activedescendant', id);
+    },
+    
+    getAriaActivedescendant: function getAriaActivedescendant() {
+      return this.$input.attr('aria-activedescendant');
+    },
+    
+    clearAriaActivedescendant: function clearAriaActivedescendant() {
+      this.$input.removeAttr('aria-activedescendant');
+    },
+    
+    setAriaExpanded: function setAriaExpanded(value) {
+      this.$input.attr('aria-expanded', value);
+    },
+    
+    getAriaExpanded: function getAriaExpanded() {
+      return this.$input.attr('aria-expanded');
+    },
 
     getLanguageDirection: function getLanguageDirection() {
       return (this.$input.css('direction') || 'ltr').toLowerCase();

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -99,12 +99,14 @@ var Typeahead = (function() {
       var datum = this.dropdown.getDatumForCursor();
 
       this.input.setInputValue(datum.value, true);
+      this.input.setAriaActivedescendant(datum.id);
 
       this.eventBus.trigger('cursorchanged', datum.raw, datum.datasetName);
     },
 
     _onCursorRemoved: function onCursorRemoved() {
       this.input.resetInputValue();
+      this.input.clearAriaActivedescendant();
       this._updateHint();
     },
 
@@ -114,12 +116,16 @@ var Typeahead = (function() {
 
     _onOpened: function onOpened() {
       this._updateHint();
-
+      
+      this.input.setAriaExpanded('true');
+      
       this.eventBus.trigger('opened');
     },
 
     _onClosed: function onClosed() {
       this.input.clearHint();
+      this.input.clearAriaActivedescendant();
+      this.input.setAriaExpanded('false');
 
       this.eventBus.trigger('closed');
     },
@@ -319,12 +325,13 @@ var Typeahead = (function() {
   return Typeahead;
 
   function buildDom(input, withHint) {
-    var $input, $wrapper, $dropdown, $hint;
+    var $input, $wrapper, $dropdown, $hint, listboxId;
 
     $input = $(input);
     $wrapper = $(html.wrapper).css(css.wrapper);
     $dropdown = $(html.dropdown).css(css.dropdown);
     $hint = $input.clone().css(css.hint).css(getBackgroundStyles($input));
+    listboxId = 'tt-listbox-'+_.getUniqueId();
 
     $hint
     .val('')
@@ -332,7 +339,7 @@ var Typeahead = (function() {
     .addClass('tt-hint')
     .removeAttr('id name placeholder required')
     .prop('readonly', true)
-    .attr({ autocomplete: 'off', spellcheck: 'false', tabindex: -1 });
+    .attr({ autocomplete: 'off', spellcheck: 'false', tabindex: -1, 'aria-hidden': true });
 
     // store the original values of the attrs that get modified
     // so modifications can be reverted on destroy
@@ -340,12 +347,18 @@ var Typeahead = (function() {
       dir: $input.attr('dir'),
       autocomplete: $input.attr('autocomplete'),
       spellcheck: $input.attr('spellcheck'),
-      style: $input.attr('style')
+      style: $input.attr('style'),
+      role: $input.attr('role'),
+      'aria-autocomplete': $input.attr('aria-autocomplete'),
+      'aria-expanded': $input.attr('aria-expanded'),
+      'aria-owns': $input.attr('aria-owns')
     });
+    
+    $dropdown.attr('id', listboxId);
 
     $input
     .addClass('tt-input')
-    .attr({ autocomplete: 'off', spellcheck: false })
+    .attr({ autocomplete: 'off', spellcheck: false, role: 'combobox', 'aria-autocomplete': withHint ? 'both' : 'list', 'aria-expanded': false, 'aria-owns': listboxId })
     .css(withHint ? css.input : css.inputWithNoHint);
 
     // ie7 does not like it when dir is set to auto

--- a/test/dropdown_view_spec.js
+++ b/test/dropdown_view_spec.js
@@ -253,10 +253,10 @@ describe('Dropdown', function() {
     it('should extract the datum from the suggestion element', function() {
       var $suggestion, datum;
 
-      $suggestion = $('<div>').data({ ttValue: 'one', ttDatum: 'two' });
+      $suggestion = $('<div id="three">').data({ ttValue: 'one', ttDatum: 'two' });
       datum = this.view.getDatumForSuggestion($suggestion);
 
-      expect(datum).toEqual({ value: 'one', raw: 'two' });
+      expect(datum).toEqual({ value: 'one', raw: 'two', id: 'three' });
     });
 
     it('should return null if no element is given', function() {

--- a/test/input_view_spec.js
+++ b/test/input_view_spec.js
@@ -333,6 +333,28 @@ describe('Input', function() {
       expect(this.view.getHint()).toBe('cheese');
     });
   });
+  
+  describe('#setAriaActivedescendant', function() {
+    it('should set the value of the input\'s aria-activedescendant attribute', function() {
+      this.view.setAriaActivedescendant('milk');
+      expect(this.view.getAriaActivedescendant()).toBe('milk');
+    });
+  });
+  
+  describe('#clearAriaActivedescendant', function() {
+    it('should clear the input\'s aria-activedescendant attribute', function() {
+      this.view.setAriaActivedescendant('milk');
+      this.view.clearAriaActivedescendant();
+      expect(this.view.getAriaActivedescendant()).not.toBeDefined();
+    });
+  });
+  
+  describe('#setAriaExpanded', function() {
+    it('should set the value of the input\'s aria-expanded attribute', function() {
+      this.view.setAriaExpanded('true');
+      expect(this.view.getAriaExpanded()).toBe('true');
+    });
+  });
 
   describe('#getLanguageDirection', function() {
     it('should return the language direction of the input', function() {

--- a/test/typeahead_view_spec.js
+++ b/test/typeahead_view_spec.js
@@ -56,6 +56,13 @@ describe('Typeahead', function() {
       expect(this.input.setInputValue)
       .toHaveBeenCalledWith(testDatum.value, true);
     });
+    
+    it('should update the aria-activedescendant', function() {
+      this.dropdown.trigger('cursorMoved');
+        
+      expect(this.input.setAriaActivedescendant)
+      .toHaveBeenCalledWith(testDatum.id);
+    });
 
     it('should trigger cursorchanged', function() {
       var spy;
@@ -73,6 +80,12 @@ describe('Typeahead', function() {
       this.dropdown.trigger('cursorRemoved');
 
       expect(this.input.resetInputValue).toHaveBeenCalled();
+    });
+    
+    it('should clear the aria-activedescendent', function() {
+      this.dropdown.trigger('cursorRemoved');
+        
+      expect(this.input.clearAriaActivedescendant).toHaveBeenCalled();
     });
 
     it('should update the hint', function() {
@@ -130,6 +143,12 @@ describe('Typeahead', function() {
 
       expect(spy).toHaveBeenCalled();
     });
+    
+    it('should set the input\'s aria-expanded attribute to true', function() {
+      this.dropdown.trigger('opened');
+        
+      expect(this.input.setAriaExpanded).toHaveBeenCalledWith('true');
+    });
   });
 
   describe('when dropdown triggers closed', function() {
@@ -147,6 +166,18 @@ describe('Typeahead', function() {
       this.dropdown.trigger('closed');
 
       expect(spy).toHaveBeenCalled();
+    });
+    
+    it('should set the input\'s aria-expanded attribute to false', function() {
+      this.dropdown.trigger('closed');
+        
+      expect(this.input.setAriaExpanded).toHaveBeenCalledWith('false');
+    });
+    
+    it('should clear the aria-activedescendent', function() {
+      this.dropdown.trigger('cursorRemoved');
+        
+      expect(this.input.clearAriaActivedescendant).toHaveBeenCalled();
     });
   });
 
@@ -562,6 +593,8 @@ describe('Typeahead', function() {
 
     it('should revert DOM changes', function() {
       this.view.destroy();
+      
+      expect(this.view.getAriaExpanded).not.toBeDefined();
 
       // TODO: bad test
       expect(this.$input).not.toHaveClass('tt-input');


### PR DESCRIPTION
This pull request adds WAI-ARIA support to typeahead re: issue #397. The implementation follows W3C guidelines outlined on http://www.w3.org/TR/wai-aria/roles#combobox, and borrowed some ideas from PR #995.

Adds following features:
Input: role=“combobox”, aria-autocomplete, aria-expanded, aria-owns, aria-activedescendant
Dropdown: role=“listbox”
Suggestion: role=“option”
Hint: aria-hidden="true"