### PR TITLE
Array parameter support in object tokenizers

### DIFF
--- a/src/bloodhound/tokenizers.js
+++ b/src/bloodhound/tokenizers.js
@@ -27,8 +27,13 @@ var tokenizers = (function() {
   }
 
   function getObjTokenizer(tokenizer) {
-    return function setKey(/* key, ... */) {
-      var args = [].slice.call(arguments, 0);
+    return function setKey(key1/*, key2, ... */) {
+      var args;
+      if (_.isArray(key1)) {
+        args = key1;
+      } else {
+        args = [].slice.call(arguments, 0);
+      }
 
       return function tokenize(o) {
         var tokens = [];


### PR DESCRIPTION
Useful for passing dynamic keys, or like in my case for an Bloodhound
wrapper.