### PR TITLE
Added the letter 'a' to the word 'typeahead'

### DIFF
--- a/doc/bloodhound.md
+++ b/doc/bloodhound.md
@@ -273,7 +273,7 @@ tokens...
 
 ...it would be a valid match for queries such as:
 
-* `typehead`
-* `typehead.js`
+* `typeahead`
+* `typeahead.js`
 * `autoco`
 * `java type`


### PR DESCRIPTION
See first two bullet points in the final paragraph of the page.  (I think these changes are correct).