### PR TITLE
OnMouseEnter trigger cursorMoved

### DIFF
--- a/src/typeahead/dropdown.js
+++ b/src/typeahead/dropdown.js
@@ -55,6 +55,7 @@ var Dropdown = (function() {
     _onSuggestionMouseEnter: function onSuggestionMouseEnter($e) {
       this._removeCursor();
       this._setCursor($($e.currentTarget), true);
+      this.trigger("cursorMoved");      
     },
 
     _onSuggestionMouseLeave: function onSuggestionMouseLeave() {


### PR DESCRIPTION
By emitting this event here, we can now give a mechanism for ancillary
queries to be executed when a users opts not to use the arrow keys, but
their mouse to hover over suggestions.