### PR TITLE
Bloodhound optionally indexes/matches remote data (backport to master)

### DIFF
--- a/doc/bloodhound.md
+++ b/doc/bloodhound.md
@@ -244,6 +244,11 @@ When configuring `remote`, the following options are available.
   transforms the response body into an array of datums. Expected to return an 
   array of datums.
 
+* `indexResponse` - If `true`, causes data fetched from remote to be added to
+  the index, along with local and prefetched data. This is useful, for example,
+  when trying to confirm that new tokens were suggested before adding them.
+  Defaults to `false`.
+
 * `ajax` – The [ajax settings object] passed to `jQuery.ajax`.
 
 <!-- section links -->

--- a/src/bloodhound/bloodhound.js
+++ b/src/bloodhound/bloodhound.js
@@ -100,7 +100,10 @@
       return this.transport.get(url, this.remote.ajax, handleRemoteResponse);
 
       function handleRemoteResponse(err, resp) {
-        err ? cb([]) : cb(that.remote.filter ? that.remote.filter(resp) : resp);
+        var data=that.remote.filter ? that.remote.filter(resp) : resp;
+        if(that.remote.indexResponse)
+          that.add(data);
+        err ? cb([]) : cb(data);
       }
     },
 

--- a/src/bloodhound/options_parser.js
+++ b/src/bloodhound/options_parser.js
@@ -56,6 +56,7 @@ var oParser = (function() {
       rateLimitWait: 300,
       send: null,
       filter: null,
+      indexResponse: false,
       ajax: {}
     };
 


### PR DESCRIPTION
Possible fix for #1148. Inspired by https://github.com/twitter/typeahead.js/pull/1149, but backported to master for v0.10.5.