### PR TITLE
Update 'normalizeQuery' integer handling in case of second loading

### DIFF
--- a/dist/bloodhound.js
+++ b/dist/bloodhound.js
@@ -1,7 +1,7 @@
 /*!
  * typeahead.js 0.10.5
  * https://github.com/twitter/typeahead.js
- * Copyright 2013-2014 Twitter, Inc. and other contributors; Licensed MIT
+ * Copyright 2013-2015 Twitter, Inc. and other contributors; Licensed MIT
  */
 
 (function($) {

--- a/dist/typeahead.bundle.js
+++ b/dist/typeahead.bundle.js
@@ -1,7 +1,7 @@
 /*!
  * typeahead.js 0.10.5
  * https://github.com/twitter/typeahead.js
- * Copyright 2013-2014 Twitter, Inc. and other contributors; Licensed MIT
+ * Copyright 2013-2015 Twitter, Inc. and other contributors; Licensed MIT
  */
 
 (function($) {
@@ -995,6 +995,7 @@
             this.$overflowHelper = buildOverflowHelper(this.$input);
         }
         Input.normalizeQuery = function(str) {
+            str = _.isString(str) ? str : _.toStr(str);
             return (str || "").replace(/^\s*/g, "").replace(/\s{2,}/g, " ");
         };
         _.mixin(Input.prototype, EventEmitter, {

--- a/dist/typeahead.jquery.js
+++ b/dist/typeahead.jquery.js
@@ -1,7 +1,7 @@
 /*!
  * typeahead.js 0.10.5
  * https://github.com/twitter/typeahead.js
- * Copyright 2013-2014 Twitter, Inc. and other contributors; Licensed MIT
+ * Copyright 2013-2015 Twitter, Inc. and other contributors; Licensed MIT
  */
 
 (function($) {
@@ -397,6 +397,7 @@
             this.$overflowHelper = buildOverflowHelper(this.$input);
         }
         Input.normalizeQuery = function(str) {
+            str = _.isString(str) ? str : _.toStr(str);
             return (str || "").replace(/^\s*/g, "").replace(/\s{2,}/g, " ");
         };
         _.mixin(Input.prototype, EventEmitter, {

--- a/src/typeahead/input.js
+++ b/src/typeahead/input.js
@@ -82,6 +82,7 @@ var Input = (function() {
 
   Input.normalizeQuery = function(str) {
     // strips leading whitespace and condenses all whitespace
+    str = _.isString(str) ? str : _.toStr(str);
     return (str || '').replace(/^\s*/g, '').replace(/\s{2,}/g, ' ');
   };
 


### PR DESCRIPTION
If we input 'integer' in case of loading typeahead.js in second time, this script has following error.
`Uncaught TypeError: undefined is not a function`

It is a treatment of above error.