### PR TITLE
Add example of capturing custom events to docs

### DIFF
--- a/doc/jquery_typeahead.md
+++ b/doc/jquery_typeahead.md
@@ -336,6 +336,18 @@ The typeahead component triggers the following custom events.
 
 All custom events are triggered on the element initialized as a typeahead.
 
+#### Custom Events Example
+The custom events listed above are used by calling jQuery `.bind()` method on a
+typeahead element. For example, the `typeahead:selected` event could be caputed
+with:
+```
+$('#studentSearch').bind('typeahead:selected', function(obj, datum, name) {
+		console.log(datum);
+	});
+```
+Note: Every event does not supply the same parameters. See the event
+descriptions above for details on each event's parameter list.
+
 ### Look and Feel
 
 Below is a faux mustache template describing the DOM structure of a typeahead 


### PR DESCRIPTION
This pull-requests adds an example to the docs for how to catch a custom typeahead event.

Seems people have been looking for an example of how to catch custom typeahead events since April 2013. Looks like an example may have been added at some point (#422), but is no longer in the docs. Also refs #300, #174