### PR TITLE
Fix `npm test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "yiewd": "^0.5.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/karma start --single-run --browsers PhantomJS"
+    "test": "./node_modules/karma/bin/karma start --single-run --browsers PhantomJS"
   },
   "version": "0.11.0",
   "main": "dist/typeahead.bundle.js"


### PR DESCRIPTION
`npm test` doesn't work:
```
> typeahead.js@0.11.0 test /home/vagrant/typeahead.js
> karma start --single-run --browsers PhantomJS

sh: 1: karma: not found
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```

See [Karma v0.11.3 breaking changes](https://github.com/karma-runner/karma/blob/6d2e4a7751a04284ce0836eba72cbe844933be9e/CHANGELOG.md#breaking-changes-2)