### PR TITLE
Bloodhound optionally indexes/matches remote data (part duex)

### DIFF
--- a/doc/bloodhound.md
+++ b/doc/bloodhound.md
@@ -272,6 +272,10 @@ When configuring `remote`, the following options are available.
   you to transform the remote response before the Bloodhound instance operates 
   on it. Defaults to the [identity function].
 
+* `indexResponse` – Adds the remote response to the index (combined with local 
+  and prefetched data). Then returns filtered results based on the query. Defaults 
+  to `false`.
+
 <!-- section links -->
 
 [identity function]: http://en.wikipedia.org/wiki/Identity_function

--- a/doc/bloodhound.md
+++ b/doc/bloodhound.md
@@ -193,6 +193,9 @@ options you can configure.
   the internal search index is insufficient or, if more configurability is 
   needed, a [remote options hash](#remote).
 
+* `indexRemote` – Adds the data loaded from `remote` to the search index (where
+  `local` and `prefetch` are stored for retrieval). Defaults to `false`.
+
 <!-- section links -->
 
 [compare function]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
@@ -252,15 +255,15 @@ When configuring `remote`, the following options are available.
 * `url` – The URL remote data should be loaded from. **Required.**
 
 * `prepare` – A function that provides a hook to allow you to prepare the 
-  settings object passed to `transport` when a request is about to be made. 
-  The function signature should be `prepare(query, settings)`, where `query` is
-  the query `#search` was called with and `settings` is the default settings
-  object created internally by the Bloodhound instance. The `prepare` function
-  should return a settings object. Defaults to the [identity function].
+   settings object passed to `transport` when a request is about to be made. 
+   The function signature should be `prepare(query, settings)`, where `query` is
+   the query `#search` was called with and `settings` is the default settings
+   object created internally by the Bloodhound instance. The `prepare` function
+   should return a settings object. Defaults to the [identity function].
 
 * `wildcard` – A convenience option for `prepare`. If set, `prepare` will be a
-  function that replaces the value of this option in `url` with the URI encoded
-  query.
+   function that replaces the value of this option in `url` with the URI encoded
+   query.
 
 * `rateLimitBy` – The method used to rate-limit network requests. Can be either 
   `debounce` or `throttle`. Defaults to `debounce`.
@@ -269,12 +272,8 @@ When configuring `remote`, the following options are available.
   `rateLimitBy`. Defaults to `300`.
 
 * `transform` – A function with the signature `transform(response)` that allows
-  you to transform the remote response before the Bloodhound instance operates 
-  on it. Defaults to the [identity function].
-
-* `indexResponse` – Adds the remote response to the index (combined with local 
-  and prefetched data). Then returns filtered results based on the query. Defaults 
-  to `false`.
+   you to transform the remote response before the Bloodhound instance operates 
+   on it. Defaults to the [identity function].
 
 <!-- section links -->
 

--- a/src/bloodhound/bloodhound.js
+++ b/src/bloodhound/bloodhound.js
@@ -20,6 +20,7 @@ var Bloodhound = (function() {
     this.sorter = o.sorter;
     this.identify = o.identify;
     this.sufficient = o.sufficient;
+    this.indexRemote = o.indexRemote;
 
     this.local = o.local;
     this.remote = o.remote ? new Remote(o.remote) : null;
@@ -132,6 +133,9 @@ var Bloodhound = (function() {
     search: function search(query, sync, async) {
       var that = this, local;
 
+      sync = sync || _.noop;
+      async = async || _.noop;
+
       local = this.sorter(this.index.search(query));
 
       // return a copy to guarantee no changes within this scope
@@ -160,12 +164,9 @@ var Bloodhound = (function() {
         });
 
         // #1148: Should Bloodhound index remote datums?
-        if (that.remote.indexResponse) {
-          that.index.add(nonDuplicates);
-          nonDuplicates = that.index.search(query);
-        }
+        that.indexRemote && that.add(nonDuplicates);
 
-        async && async(nonDuplicates);
+        async(nonDuplicates);
       }
     },
 

--- a/src/bloodhound/bloodhound.js
+++ b/src/bloodhound/bloodhound.js
@@ -159,6 +159,12 @@ var Bloodhound = (function() {
           }) && nonDuplicates.push(r);
         });
 
+        // #1148: Should Bloodhound index remote datums?
+        if (that.remote.indexResponse) {
+          that.index.add(nonDuplicates);
+          nonDuplicates = that.index.search(query);
+        }
+
         async && async(nonDuplicates);
       }
     },

--- a/src/bloodhound/options_parser.js
+++ b/src/bloodhound/options_parser.js
@@ -16,6 +16,7 @@ var oParser = (function() {
       datumTokenizer: null,
       queryTokenizer: null,
       sufficient: 5,
+      indexRemote: false,
       sorter: null,
       local: [],
       prefetch: null,

--- a/src/bloodhound/remote.js
+++ b/src/bloodhound/remote.js
@@ -14,6 +14,7 @@ var Remote = (function() {
     this.url = o.url;
     this.prepare = o.prepare;
     this.transform = o.transform;
+    this.indexResponse = o.indexResponse;
 
     this.transport = new Transport({
       cache: o.cache,

--- a/test/bloodhound/bloodhound_spec.js
+++ b/test/bloodhound/bloodhound_spec.js
@@ -289,6 +289,57 @@ describe('Bloodhound', function() {
 
       function fakeGet(o, cb) { cb(fixtures.data.animals); }
     });
+
+    it('should not add remote data to index if indexRemote is false', function() {
+      this.bloodhound = build({
+        identify: function(d) { return d.value; },
+        remote: '/remote'
+      });
+      this.bloodhound.remote.get.andCallFake(fakeGet);
+
+      spyOn(this.bloodhound, 'add');
+      this.bloodhound.search('dog');
+
+      expect(this.bloodhound.add).not.toHaveBeenCalled();
+
+      function fakeGet(o, cb) { cb(fixtures.data.animals); }
+    });
+
+    it('should add remote data to index if indexRemote is true', function() {
+      this.bloodhound = build({
+        identify: function(d) { return d.value; },
+        indexRemote: true,
+        remote: '/remote'
+      });
+      this.bloodhound.remote.get.andCallFake(fakeGet);
+
+      spyOn(this.bloodhound, 'add');
+      this.bloodhound.search('dog');
+
+      expect(this.bloodhound.add).toHaveBeenCalledWith(fixtures.data.animals);
+
+      function fakeGet(o, cb) { cb(fixtures.data.animals); }
+    });
+
+    it('should not add duplicates from remote to index', function() {
+      this.bloodhound = build({
+        identify: function(d) { return d.value; },
+        indexRemote: true,
+        local: fixtures.data.animals,
+        remote: '/remote'
+      });
+      this.bloodhound.remote.get.andCallFake(fakeGet);
+
+      spyOn(this.bloodhound, 'add');
+      this.bloodhound.search('dog');
+
+      expect(this.bloodhound.add).toHaveBeenCalledWith([
+        { value: 'cat' },
+        { value: 'moose' }
+      ]);
+
+      function fakeGet(o, cb) { cb(fixtures.data.animals); }
+    });
   });
 
   // helper functions


### PR DESCRIPTION
Fork of #1149. Moves `indexRemote` to top-level option.