### PR TITLE
Fix 'Mixed Content' error by loading backend from HTTPs

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -3,7 +3,7 @@ $(document).ready(function() {
 
   $.support.cors = true;
 
-  remoteHost = 'http://typeahead-js-twitter-api-proxy.herokuapp.com';
+  remoteHost = 'https://typeahead-js-twitter-api-proxy.herokuapp.com';
   template = Handlebars.compile($("#result-template").html());
   empty = Handlebars.compile($("#empty-template").html());
 


### PR DESCRIPTION
Fixes the demo:

> Mixed Content: The page at 'https://twitter.github.io/typeahead.js/' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://typeahead-js-twitter-api-proxy.herokuapp.com/demo/search?q=type'. This request has been blocked; the content must be served over HTTPS.
