### PR TITLE
Fixed typo in the documentation for the search function

### DIFF
--- a/doc/bloodhound.md
+++ b/doc/bloodhound.md
@@ -136,7 +136,7 @@ contain at least `sufficient` number of datums, `remote` data will be requested
 and then passed to the `async` callback.
 
 ```javascript
-bloodhound.get(myQuery, sync, async);
+bloodhound.search(myQuery, sync, async);
 
 function sync(datums) {
   console.log('datums from `local`, `prefetch`, and `#add`');


### PR DESCRIPTION
I noticed a typo in the documentation for "search"; "get" had been used instead of "search".  See my change to the .md file.
