### PR TITLE
Fix async not working

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,10 +269,10 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          rendered += suggestions.length;
           that._append(query, suggestions.slice(0, that.limit - rendered));
 
           that.async && that.trigger('asyncReceived', query);
+          rendered += suggestions.length;
         }
       }
     },


### PR DESCRIPTION
Wouldn’t work before because `rendered` would already be set to
`suggestions.length` before `that._append` is called, making
the `suggestions.slice(0, that.limit - rendered)` call return an empty
array.
