### PR TITLE
Invert bundle inclusion order

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -112,8 +112,8 @@ module.exports = function(grunt) {
           compress: false
         },
         src: [
-          '<%= tempDir %>/bloodhound.js',
-          '<%= tempDir %>/typeahead.jquery.js'
+          '<%= tempDir %>/typeahead.jquery.js',
+          '<%= tempDir %>/bloodhound.js'
         ],
         dest: '<%= buildDir %>/typeahead.bundle.js'
 


### PR DESCRIPTION
If typeahead component is included after Bloodhound, Bloodhound module is never exported to use with Browserify. Fixes #1214 
