### PR TITLE
spell-correcting idenityPrepare to identityPrepare

### DIFF
--- a/src/bloodhound/options_parser.js
+++ b/src/bloodhound/options_parser.js
@@ -129,7 +129,7 @@ var oParser = (function() {
     }
 
     else {
-      prepare = idenityPrepare;
+      prepare = identityPrepare;
     }
 
     return prepare;
@@ -144,7 +144,7 @@ var oParser = (function() {
       return settings;
     }
 
-    function idenityPrepare(query, settings) {
+    function identityPrepare(query, settings) {
       return settings;
     }
   }


### PR DESCRIPTION
I noticed a potential typo while looking at the source.  I believe the name of the function should have been "identityPrepare" and not "idenityPrepare".  Thanks.
