### PR TITLE
clarifying wildcard in the documentation

### DIFF
--- a/doc/bloodhound.md
+++ b/doc/bloodhound.md
@@ -260,7 +260,7 @@ When configuring `remote`, the following options are available.
 
 * `wildcard` – A convenience option for `prepare`. If set, `prepare` will be a
   function that replaces the value of this option in `url` with the URI encoded
-  query.
+  query. In older versions of typeahead, this was `%QUERY` and now should now be manually specified as such.
 
 * `rateLimitBy` – The method used to rate-limit network requests. Can be either 
   `debounce` or `throttle`. Defaults to `debounce`.


### PR DESCRIPTION
At least _for me_, it wasn't clear how the old style of url with the pre-baked `%QUERY` string was to be updated to be compatible with newer versions.  I had to refer to the source. 

This documentation add-on addresses what I believe will be a common reason that people will be referring to this section of the documentation. 

Thanks.
