### PR TITLE
Fix async results when limit is reached

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,8 +269,8 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          rendered += suggestions.length;
           that._append(query, suggestions.slice(0, that.limit - rendered));
+          rendered += suggestions.length;
 
           that.async && that.trigger('asyncReceived', query);
         }


### PR DESCRIPTION
When we get the async results, we want to stripe some results, depending on the count of results already received synchronously. 
The rendered prop was updated too soon, causing too many items to be dropped.
