### PR TITLE
Add `changeInputValue` option to typeahead

### DIFF
--- a/src/typeahead/plugin.js
+++ b/src/typeahead/plugin.js
@@ -44,7 +44,7 @@
         $hint = $elOrNull(o.hint);
         $menu = $elOrNull(o.menu);
 
-        defaultHint = o.hint !== false && !$hint;
+        defaultHint = o.changeInputValue !== false && o.hint !== false && !$hint;
         defaultMenu = o.menu !== false && !$menu;
 
         defaultHint && ($hint = buildHintFromInput($input, www));

--- a/src/typeahead/plugin.js
+++ b/src/typeahead/plugin.js
@@ -79,7 +79,8 @@
           input: input,
           menu: menu,
           eventBus: eventBus,
-          minLength: o.minLength
+          minLength: o.minLength,
+          changeInputValue: o.changeInputValue
         }, www);
 
         $input.data(keys.www, www);

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -33,7 +33,8 @@ var Typeahead = (function() {
 
     this.eventBus = o.eventBus;
     this.minLength = _.isNumber(o.minLength) ? o.minLength : 1;
-
+    this.changeInputValue = !_.isUndefined(o.changeInputValue) ? o.changeInputValue : true;
+    
     this.input = o.input;
     this.menu = o.menu;
 
@@ -348,8 +349,11 @@ var Typeahead = (function() {
       var data = this.menu.getSelectableData($selectable);
 
       if (data && !this.eventBus.before('select', data.obj)) {
-        this.input.setQuery(data.val, true);
-
+        
+        if (this.changeInputValue) {
+          this.input.setQuery(data.val, true);
+        }
+        
         this.eventBus.trigger('select', data.obj);
         this.close();
 
@@ -368,7 +372,9 @@ var Typeahead = (function() {
       isValid = data && query !== data.val;
 
       if (isValid && !this.eventBus.before('autocomplete', data.obj)) {
-        this.input.setQuery(data.val);
+        if (this.changeInputValue) {
+          this.input.setQuery(data.val);
+        }
         this.eventBus.trigger('autocomplete', data.obj);
 
         // return true if autocompletion succeeded
@@ -394,12 +400,12 @@ var Typeahead = (function() {
         this.menu.setCursor($candidate);
 
         // cursor moved to different selectable
-        if (data) {
+        if (data && this.changeInputValue) {
           this.input.setInputValue(data.val);
         }
 
         // cursor moved off of selectables, back to input
-        else {
+        else if (this.changeInputValue) {
           this.input.resetInputValue();
           this._updateHint();
         }


### PR DESCRIPTION
Per issue #884 

Passing `changeInputValue: false` to `typeahead` options will disable hinting and prevent the plugin from changing the input value on cursor change or select.

Use case: navigating to another page on selection and using the raw value in addition to the selected data.

![image](https://cloud.githubusercontent.com/assets/563819/7841970/832dc8aa-04a0-11e5-915b-e4e21081ceaa.png)

![image](https://cloud.githubusercontent.com/assets/563819/7841981/9627c834-04a0-11e5-90f3-a92a6da90b42.png)

**Usage:**

```
$(el).typeahead({
  changeInputValue: false
}, [datasets]);
```
