### PR TITLE
Support ctrl-n and ctrl-p for down/up navigation

### DIFF
--- a/src/typeahead/input.js
+++ b/src/typeahead/input.js
@@ -7,18 +7,6 @@
 var Input = (function() {
   'use strict';
 
-  var specialKeyCodeMap;
-
-  specialKeyCodeMap = {
-    9: 'tab',
-    27: 'esc',
-    37: 'left',
-    39: 'right',
-    13: 'enter',
-    38: 'up',
-    40: 'down'
-  };
-
   // constructor
   // -----------
 
@@ -83,7 +71,7 @@ var Input = (function() {
 
     _onKeydown: function onKeydown($e) {
       // which is normalized and consistent (but not for ie)
-      var keyName = specialKeyCodeMap[$e.which || $e.keyCode];
+      var keyName = this._specialKey($e);
 
       this._managePreventDefault(keyName, $e);
       if (keyName && this._shouldTrigger(keyName, $e)) {
@@ -98,6 +86,18 @@ var Input = (function() {
     },
 
     // ### private
+
+    _specialKey: function _specialKey($e) {
+      var key = $e.which || $e.keyCode;
+
+      if (key == 9) { return 'tab'; }
+      else if (key == 27) { return 'esc';   }
+      else if (key == 37) { return 'left';  }
+      else if (key == 39) { return 'right'; }
+      else if (key == 13) { return 'enter'; }
+      else if (key == 38 || (key == 80 && $e.ctrlKey)) { return 'up';  }
+      else if (key == 40 || (key == 78 && $e.ctrlKey)) { return 'down';  }
+    },
 
     _managePreventDefault: function managePreventDefault(keyName, $e) {
       var preventDefault;
@@ -183,7 +183,7 @@ var Input = (function() {
       else {
         this.$input.on('keydown.tt keypress.tt cut.tt paste.tt', function($e) {
           // if a special key triggered this, ignore it
-          if (specialKeyCodeMap[$e.which || $e.keyCode]) { return; }
+          if ( this._specialKey($e) ) { return; }
 
           // give the browser a chance to update the value of the input
           // before checking to see if the query changed

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -240,6 +240,44 @@ describe('jquery-typeahead.js', function() {
     });
   });
 
+  describe('on ctrl-p', function() {
+    it('should cycle through suggestions', function(done) {
+      driver.run(function*() {
+        var suggestions;
+
+        yield input.click();
+        yield input.type('mi');
+
+        suggestions = yield dropdown.elementsByClassName('tt-suggestion');
+
+        yield input.type([wd.SPECIAL_KEYS['Control'], 'p']);
+        expect(yield input.getValue()).to.equal('Missouri');
+        expect(yield suggestions[3].getAttribute('class')).to.equal('tt-suggestion tt-selectable tt-cursor');
+
+        yield input.type([wd.SPECIAL_KEYS['Control'], 'p']);
+        expect(yield input.getValue()).to.equal('Mississippi');
+        expect(yield suggestions[2].getAttribute('class')).to.equal('tt-suggestion tt-selectable tt-cursor');
+
+        yield input.type([wd.SPECIAL_KEYS['Control'], 'p']);
+        expect(yield input.getValue()).to.equal('Minnesota');
+        expect(yield suggestions[1].getAttribute('class')).to.equal('tt-suggestion tt-selectable tt-cursor');
+
+        yield input.type([wd.SPECIAL_KEYS['Control'], 'p']);
+        expect(yield input.getValue()).to.equal('Michigan');
+        expect(yield suggestions[0].getAttribute('class')).to.equal('tt-suggestion tt-selectable tt-cursor');
+
+        yield input.type([wd.SPECIAL_KEYS['Control'], 'p']);
+        expect(yield input.getValue()).to.equal('mi');
+        expect(yield suggestions[0].getAttribute('class')).to.equal('tt-suggestion tt-selectable');
+        expect(yield suggestions[1].getAttribute('class')).to.equal('tt-suggestion tt-selectable');
+        expect(yield suggestions[2].getAttribute('class')).to.equal('tt-suggestion tt-selectable');
+        expect(yield suggestions[3].getAttribute('class')).to.equal('tt-suggestion tt-selectable');
+
+        done();
+      });
+    });
+  });
+
   describe('on down arrow', function() {
     it('should cycle through suggestions', function(done) {
       driver.run(function*() {
@@ -267,6 +305,44 @@ describe('jquery-typeahead.js', function() {
         expect(yield suggestions[3].getAttribute('class')).to.equal('tt-suggestion tt-selectable tt-cursor');
 
         yield input.type(wd.SPECIAL_KEYS['Down arrow']);
+        expect(yield input.getValue()).to.equal('mi');
+        expect(yield suggestions[0].getAttribute('class')).to.equal('tt-suggestion tt-selectable');
+        expect(yield suggestions[1].getAttribute('class')).to.equal('tt-suggestion tt-selectable');
+        expect(yield suggestions[2].getAttribute('class')).to.equal('tt-suggestion tt-selectable');
+        expect(yield suggestions[3].getAttribute('class')).to.equal('tt-suggestion tt-selectable');
+
+        done();
+      });
+    });
+  });
+
+  describe('on ctrl-n', function() {
+    it('should cycle through suggestions', function(done) {
+      driver.run(function*() {
+        var suggestions;
+
+        yield input.click();
+        yield input.type('mi');
+
+        suggestions = yield dropdown.elementsByClassName('tt-suggestion');
+
+        yield input.type([wd.SPECIAL_KEYS['Control'], 'n']);
+        expect(yield input.getValue()).to.equal('Michigan');
+        expect(yield suggestions[0].getAttribute('class')).to.equal('tt-suggestion tt-selectable tt-cursor');
+
+        yield input.type([wd.SPECIAL_KEYS['Control'], 'n']);
+        expect(yield input.getValue()).to.equal('Minnesota');
+        expect(yield suggestions[1].getAttribute('class')).to.equal('tt-suggestion tt-selectable tt-cursor');
+
+        yield input.type([wd.SPECIAL_KEYS['Control'], 'n']);
+        expect(yield input.getValue()).to.equal('Mississippi');
+        expect(yield suggestions[2].getAttribute('class')).to.equal('tt-suggestion tt-selectable tt-cursor');
+
+        yield input.type([wd.SPECIAL_KEYS['Control'], 'n']);
+        expect(yield input.getValue()).to.equal('Missouri');
+        expect(yield suggestions[3].getAttribute('class')).to.equal('tt-suggestion tt-selectable tt-cursor');
+
+        yield input.type([wd.SPECIAL_KEYS['Control'], 'n']);
         expect(yield input.getValue()).to.equal('mi');
         expect(yield suggestions[0].getAttribute('class')).to.equal('tt-suggestion tt-selectable');
         expect(yield suggestions[1].getAttribute('class')).to.equal('tt-suggestion tt-selectable');


### PR DESCRIPTION
The feature suggestion wasn't accepted (#103) and suggested another way,
but I'm happy if it is supported without any hack.

There are some people don't want to type arrow key, I think.
For example, [atwho](https://github.com/ichord/At.js/pull/142) has ctrl-n and ctrl-p key bindings.
