### PR TITLE
Fix small results count handling

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,7 +269,7 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          suggestions = suggestions.slice(0, Math.min(that.limit, rendered));
+          suggestions = suggestions.slice(0, Math.min(that.limit, suggestions.length));
           rendered += suggestions.length;
           that._append(query, suggestions);
 

--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,7 +269,8 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          suggestions = suggestions.slice(0, Math.min(that.limit, suggestions.length));
+          var count = Math.min(that.limit, suggestions.length, that.limit - rendered);
+          suggestions = suggestions.slice(0, count);
           rendered += suggestions.length;
           that._append(query, suggestions);
 

--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,8 +269,9 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
+          suggestions = suggestions.slice(0, Math.min(that.limit, rendered));
           rendered += suggestions.length;
-          that._append(query, suggestions.slice(0, Math.min(that.limit, rendered)));
+          that._append(query, suggestions);
 
           that.async && that.trigger('asyncReceived', query);
         }

--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -270,7 +270,7 @@ var Dataset = (function() {
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
           rendered += suggestions.length;
-          that._append(query, suggestions.slice(0, that.limit - rendered));
+          that._append(query, suggestions.slice(0, Math.min(that.limit, rendered)));
 
           that.async && that.trigger('asyncReceived', query);
         }


### PR DESCRIPTION
When returning less than or equal to limit number of results, not all results are shown. In the worst case (equal to limit) no results are shown. Also, fixed the rendered count.
