### PR TITLE
Update jquery_typeahead.md

### DIFF
--- a/doc/jquery_typeahead.md
+++ b/doc/jquery_typeahead.md
@@ -211,7 +211,7 @@ a typeahead.
   were fetched asynchronously, and the name of the dataset the rendering 
   occurred in.
 
-* `typeahead:select` – Fired when a suggestion is selected. The event handler 
+* `typeahead:selected` – Fired when a suggestion is selected. The event handler 
   will be invoked with 2 arguments: the jQuery event object and the suggestion
   object that was selected.
 


### PR DESCRIPTION
event is called selected (i think, typeahead:select does not work for me, while selected does)
