### PR TITLE
fix absence of result with async

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -263,14 +263,13 @@ var Dataset = (function() {
       }
 
       function async(suggestions) {
-        suggestions = suggestions || [];
-
         // if the update has been canceled or if the query has changed
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
+          suggestions = (suggestions || []).slice(0, that.limit - rendered);
           that.cancel = $.noop;
+          that._append(query, suggestions);
           rendered += suggestions.length;
-          that._append(query, suggestions.slice(0, that.limit - rendered));
 
           that.async && that.trigger('asyncReceived', query);
         }


### PR DESCRIPTION
There was an issue when `async` was called on a `suggestions` array such as `suggestions.length == that.limit - rendered`
The code ended up calling `suggestions.slice(0, 0)` and nothing was rendered.

Following this change, the `async` code is more in line with what the `sync` code does.
