### PR TITLE
fix #1314 - limit doesn't work properly with more than one digit

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,8 +269,10 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          rendered += suggestions.length;
-          that._append(query, suggestions.slice(0, that.limit - rendered));
+          var addable = that.limit - rendered;
+          var added = Math.min(addable, suggestions.length);
+          that._append(query, suggestions.slice(0, added));
+          rendered += added;
 
           that.async && that.trigger('asyncReceived', query);
         }


### PR DESCRIPTION
the suggestions where sliced with:
   rendered += suggestions.length;
   suggestions.slice(0, that.limit - rendered)

which is fine as long as  limit < suggestions.length  because slicing with a negative index works
but if limit = suggestions.length then no element is rendered.
if limit > suggestions.length then the results are truncated.
