### PR TITLE
Switch jQuery to peerDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Getting Started
 
 How you acquire typeahead.js is up to you.
 
-Preferred method:
+Preferred methods:
 * Install with [Bower]: `$ bower install typeahead.js`
+* Install with [npm]: `$ npm install jquery typeahead.js`
 
 Other methods:
 * [Download zipball of latest release][zipball].
@@ -45,6 +46,7 @@ Other methods:
 <!-- section links -->
 
 [Bower]: http://bower.io/
+[npm]: https://www.npmjs.com/
 [zipball]: http://twitter.github.com/typeahead.js/releases/latest/typeahead.js.zip
 [bloodhound.js]: http://twitter.github.com/typeahead.js/releases/latest/bloodhound.js
 [typeahead.jquery.js]: http://twitter.github.com/typeahead.js/releases/latest/typeahead.jquery.js

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "url": "https://twitter.com/vskarich"
     }
   ],
-  "dependencies": {
+  "peerDependencies": {
     "jquery": ">=1.7"
   },
   "devDependencies": {


### PR DESCRIPTION
When a frontend library has a dependency which is supposed to be a "singleton" (ex: jQuery, React), I think the preferred way to go with npm is to use `peerDependencies` (ex: https://github.com/gaearon/react-dnd/blob/master/package.json).

This means you need to install jQuery manually (`npm install jquery typeahead.js`), but it also means you won't run into this issue:

``` javascript
// myapp.js
var $ = require('jquery');
require('typeahead.js');

$('.typeahead').typeahead(/*...*/);
// before this PR: "$(..).typeahead is not a function"
// after: works as expected
```

Also added npm installation instructions to README.
