### PR TITLE
[Fixes #1243] Fix IE scrolling with mouse not working with overflow-y, fix focus loss in IE8

### DIFF
--- a/src/typeahead/input.js
+++ b/src/typeahead/input.js
@@ -33,6 +33,7 @@ var Input = (function() {
 
     this.$hint = $(o.hint);
     this.$input = $(o.input);
+    this.$menu = $(o.menu);
 
     // the query defaults to whatever the value of the input is
     // on initialization, it'll most likely be an empty string
@@ -71,9 +72,32 @@ var Input = (function() {
 
     // ### event handlers
 
-    _onBlur: function onBlur() {
-      this.resetInputValue();
-      this.trigger('blurred');
+    _onBlur: function onBlur ($e) {
+        var active, isActive, hasActive, that = this;
+        active = document.activeElement;
+        isActive = this.$menu.is(active);
+        hasActive = this.$menu.has(active).length > 0;
+    
+        // #705: if there's scrollable overflow, ie doesn't support
+        // blur cancellations when the scrollbar is clicked
+        //
+        // #351, #1243: preventDefault won't cancel blurs in ie <= 8, so we refuse to trigger the "blurred" event
+        if (_.isMsie() && (isActive || hasActive)) {
+            _.defer(function() {
+                console.log ('timeout');
+                if (!that.$input.is (':focus')) {
+                    that.$input.focus();
+                };
+            });
+
+            // stop immediate in order to prevent Input#_onBlur from
+            // getting exectued
+            $e.preventDefault();
+            $e.stopImmediatePropagation();
+        } else {
+            this.resetInputValue();
+            this.trigger("blurred");
+        };
     },
 
     _onFocus: function onFocus() {

--- a/src/typeahead/plugin.js
+++ b/src/typeahead/plugin.js
@@ -69,7 +69,7 @@
         MenuConstructor = defaultMenu ? DefaultMenu : Menu;
 
         eventBus = new EventBus({ el: $input });
-        input = new Input({ hint: $hint, input: $input, }, www);
+        input = new Input({ hint: $hint, input: $input, menu: $menu, }, www);
         menu = new MenuConstructor({
           node: $menu,
           datasets: datasets

--- a/src/typeahead/typeahead.js
+++ b/src/typeahead/typeahead.js
@@ -91,31 +91,7 @@ var Typeahead = (function() {
 
     // here's where hacks get applied and we don't feel bad about it
     _hacks: function hacks() {
-      var $input, $menu;
-
-      // these default values are to make testing easier
-      $input = this.input.$input || $('<div>');
-      $menu = this.menu.$node || $('<div>');
-
-      // #705: if there's scrollable overflow, ie doesn't support
-      // blur cancellations when the scrollbar is clicked
-      //
-      // #351: preventDefault won't cancel blurs in ie <= 8
-      $input.on('blur.tt', function($e) {
-        var active, isActive, hasActive;
-
-        active = document.activeElement;
-        isActive = $menu.is(active);
-        hasActive = $menu.has(active).length > 0;
-
-        if (_.isMsie() && (isActive || hasActive)) {
-          $e.preventDefault();
-          // stop immediate in order to prevent Input#_onBlur from
-          // getting exectued
-          $e.stopImmediatePropagation();
-          _.defer(function() { $input.focus(); });
-        }
-      });
+      var $menu = this.menu.$node || $("<div>");
 
       // #351: prevents input blur due to clicks within menu
       $menu.on('mousedown.tt', function($e) { $e.preventDefault(); });


### PR DESCRIPTION
I may have been unable to fix this cleanly, unfortunately. The thing is the "blurred" event should not be fired by the Input object of the typeahead, but the `preventDefault` and `stopImmediatePropagation` in the event caught in `_hacks` did stop the event when `overlow-y` was used.

So I have moved the code for checking this into the Input class, because the `_hacks` are unfortunately not visible from there.

Also, I failed to figure out the build and testing system, sorry.
