### PR TITLE
Fixed Chrome Autocomplete Issue

### DIFF
--- a/src/typeahead/plugin.js
+++ b/src/typeahead/plugin.js
@@ -220,7 +220,7 @@
     .css(getBackgroundStyles($input))
     .prop('readonly', true)
     .removeAttr('id name placeholder required')
-    .attr({ autocomplete: 'off', spellcheck: 'false', tabindex: -1 });
+    .attr({ autocomplete: 'false', spellcheck: 'false', tabindex: -1 });
   }
 
   function prepInput($input, www) {
@@ -235,7 +235,7 @@
 
     $input
     .addClass(www.classes.input)
-    .attr({ autocomplete: 'off', spellcheck: false });
+    .attr({ autocomplete: 'false', spellcheck: false });
 
     // ie7 does not like it when dir is set to auto
     try { !$input.attr('dir') && $input.attr('dir', 'auto'); } catch (e) {}

--- a/test/typeahead/plugin_spec.js
+++ b/test/typeahead/plugin_spec.js
@@ -158,7 +158,7 @@ describe('$plugin', function() {
   });
 
   it('#destroy should revert modified attributes', function() {
-    expect(this.$input).toHaveAttr('autocomplete', 'off');
+    expect(this.$input).toHaveAttr('autocomplete', 'false');
     expect(this.$input).toHaveAttr('dir');
     expect(this.$input).toHaveAttr('spellcheck');
     expect(this.$input).toHaveAttr('style');


### PR DESCRIPTION
Chrome no longer respects autocomplete='off' attribute. Changed to 'false' instead.
