### PR TITLE
Bloodhound: Replace getIntersection method.

### DIFF
--- a/dist/bloodhound.js
+++ b/dist/bloodhound.js
@@ -523,23 +523,18 @@
             }
             return uniques;
         }
-        function getIntersection(arrayA, arrayB) {
-            var ai = 0, bi = 0, intersection = [];
-            arrayA = arrayA.sort();
-            arrayB = arrayB.sort();
-            var lenArrayA = arrayA.length, lenArrayB = arrayB.length;
-            while (ai < lenArrayA && bi < lenArrayB) {
-                if (arrayA[ai] < arrayB[bi]) {
-                    ai++;
-                } else if (arrayA[ai] > arrayB[bi]) {
-                    bi++;
-                } else {
-                    intersection.push(arrayA[ai]);
-                    ai++;
-                    bi++;
+        function getIntersection(array) {
+            var result = [],
+                argsLength = arguments.length;
+            for (var i = 0, length = array.length; i < length; i++) {
+                var item = array[i];
+                if (result.indexOf(item) > -1) continue;
+                for (var j = 1; j < argsLength; j++) {
+                    if (arguments[j].indexOf(item) === -1) break;
                 }
+                if (j === argsLength) result.push(item);
             }
-            return intersection;
+            return result;
         }
     }();
     var Prefetch = function() {

--- a/dist/typeahead.bundle.js
+++ b/dist/typeahead.bundle.js
@@ -523,23 +523,18 @@
             }
             return uniques;
         }
-        function getIntersection(arrayA, arrayB) {
-            var ai = 0, bi = 0, intersection = [];
-            arrayA = arrayA.sort();
-            arrayB = arrayB.sort();
-            var lenArrayA = arrayA.length, lenArrayB = arrayB.length;
-            while (ai < lenArrayA && bi < lenArrayB) {
-                if (arrayA[ai] < arrayB[bi]) {
-                    ai++;
-                } else if (arrayA[ai] > arrayB[bi]) {
-                    bi++;
-                } else {
-                    intersection.push(arrayA[ai]);
-                    ai++;
-                    bi++;
+        function getIntersection(array) {
+            var result = [],
+                argsLength = arguments.length;
+            for (var i = 0, length = array.length; i < length; i++) {
+                var item = array[i];
+                if (result.indexOf(item) > -1) continue;
+                for (var j = 1; j < argsLength; j++) {
+                    if (arguments[j].indexOf(item) === -1) break;
                 }
+                if (j === argsLength) result.push(item);
             }
-            return intersection;
+            return result;
         }
     }();
     var Prefetch = function() {

--- a/src/bloodhound/search_index.js
+++ b/src/bloodhound/search_index.js
@@ -162,30 +162,22 @@ var SearchIndex = window.SearchIndex = (function() {
     return uniques;
   }
 
-  function getIntersection(arrayA, arrayB) {
-    var ai = 0, bi = 0, intersection = [];
+  function getIntersection(array) {
+    var result = [],
+        argsLength = arguments.length;
 
-    arrayA = arrayA.sort();
-    arrayB = arrayB.sort();
+    for (var i = 0, length = array.length; i < length; i++) {
+      var item = array[i];
 
-    var lenArrayA = arrayA.length, lenArrayB = arrayB.length;
+      if (result.indexOf(item) > -1) continue;
 
-    while (ai < lenArrayA && bi < lenArrayB) {
-      if (arrayA[ai] < arrayB[bi]) {
-        ai++;
+      for (var j = 1; j < argsLength; j++) {
+        if (arguments[j].indexOf(item) === -1) break;
       }
 
-      else if (arrayA[ai] > arrayB[bi]) {
-        bi++;
-      }
-
-      else {
-        intersection.push(arrayA[ai]);
-        ai++;
-        bi++;
-      }
+      if (j === argsLength) result.push(item);
     }
 
-    return intersection;
+    return result;
   }
 })();


### PR DESCRIPTION
Fixes functional error when `matches` array only has one key, and that key value is less than the first key value in the `ids`array, which results in an empty `intersection` array. Uses the same logic as the `_.intersection(array)` method from underscore.js to safely find the intersection of the two arrays.
