### PR TITLE
Fix for remote/async suggestions

### DIFF
--- a/dist/typeahead.bundle.js
+++ b/dist/typeahead.bundle.js
@@ -1720,8 +1720,9 @@
                     suggestions = suggestions || [];
                     if (!canceled && rendered < that.limit) {
                         that.cancel = $.noop;
-                        rendered += suggestions.length;
-                        that._append(query, suggestions.slice(0, that.limit - rendered));
+                        var app = suggestions.slice(0, that.limit - rendered);
+                        rendered += app.length;
+                        that._append(query, app);
                         that.async && that.trigger("asyncReceived", query);
                     }
                 }


### PR DESCRIPTION
This is probably the same issue as in #1284 but have a look.
There seems to be a problem when rendering the suggestions of a remote request.
To reproduce, set the typeahead limit=2 and have 2 items returned from the remote source => no suggestions will be rendered.
In this case the following values are set: rendered=0, limit=2, suggestions.length=2, which results in 0 sliced items.
Damn nasty thing to notice, since it only occurs when limit=suggestions.length (and because slice accepts negative numbers) :)
