### PR TITLE
Updated docs/bloodhound.md to include Tokenizers

### DIFF
--- a/doc/bloodhound.md
+++ b/doc/bloodhound.md
@@ -12,6 +12,7 @@ Table of Contents
 * [Usage](#usage)
   * [API](#api)
   * [Options](#options)
+  * [Tokenizers] (#tokenizers)
   * [Prefetch](#prefetch)
   * [Remote](#remote)
 
@@ -196,6 +197,67 @@ options you can configure.
 <!-- section links -->
 
 [compare function]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
+
+### Tokenizers
+Bloodhound has various built-in tokenizer functions which can be used in as a value for `datumTokenizer` and 
+`queryTokenizer` in [options hash](#options). 
+
+#### Bloodhound.tokenizers.nonword(str)
+Splits the string `str` on any non alphanumeric characters or underscores using: `str.split(/\W+/)`
+
+```javascript
+Bloodhound.tokenizers.nonword("I'll give bloodhound#0.11 a 8.5/10!");
+//OUTPUT: ["I", "ll", "give", "bloodhound", "0", "11", "a", "8", "5", "10", ""]
+```
+
+#### Bloodhound.tokenizers.whitespace(str)
+Splits the string `str` on any whitespaces using: `str.split(/\s+/)`. A whitespace includes spaces, tabs, carriage 
+returns, new line character, a vertical tab character & a form feed character
+
+```javascript
+Bloodhound.tokenizers.whitespace("I     like \t my space!");
+//OUTPUT: ["I", "like", "my", "space!"]
+```
+
+#### Bloodhound.tokenizers.obj.nonword([*keys])(obj)
+Performs the function [Bloodhound.tokenizers.nonword](#bloodhoundtokenizersnonword-keys-obj) on each key in `keys` 
+provided  on `obj` and then concatenates them.
+
+```javascript
+Bloodhound.tokenizers.obj.nonword("name", "message", "age")({ 
+  name: "John Smith", 
+  message: "I like Bloodhound#0.10!", 
+  age: 21, 
+  bio: "I won't be shown!"
+});
+//OUTPUT: ["John", "Smith", "I", "like", "Bloodhound", "0", "10", "", "21"]
+```
+
+#### Bloodhound.tokenizers.obj.whitespace([*keys])(obj)
+Performs the function `Bloodhound.tokenizers.whitespace` on each of the `keys` provided  on `obj` and then concatenates 
+them.
+
+```javascript
+Bloodhound.tokenizers.obj.whitespace("name", "message", "age")({ 
+  name: "John Smith", 
+  message: "I     like \t my space!", 
+  age: 21, 
+  bio: "I won't be shown!"
+});
+["John", "Smith", "I", "like", "my", "space!", "21"]
+```
+
+#### new Bloodhound(options)
+The constructor function. It takes an [options hash](#options) as its only 
+argument.
+
+```javascript
+var engine = new Bloodhound({
+  local: ['dog', 'pig', 'moose'],
+  queryTokenizer: Bloodhound.tokenizers.whitespace,
+  datumTokenizer: Bloodhound.tokenizers.whitespace
+});
+```
 
 ### Prefetch
 

--- a/doc/bloodhound.md
+++ b/doc/bloodhound.md
@@ -199,8 +199,8 @@ options you can configure.
 [compare function]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
 
 ### Tokenizers
-Bloodhound has various built-in tokenizer functions which can be used in as a value for `datumTokenizer` and 
-`queryTokenizer` in [options hash](#options). 
+Bloodhound has various built-in tokenizer functions which can be used as a value for `datumTokenizer` and 
+`queryTokenizer` in the [options](#options). 
 
 #### Bloodhound.tokenizers.nonword(str)
 Splits the string `str` on any non alphanumeric characters or underscores using: `str.split(/\W+/)`
@@ -245,18 +245,6 @@ Bloodhound.tokenizers.obj.whitespace("name", "message", "age")({
   bio: "I won't be shown!"
 });
 ["John", "Smith", "I", "like", "my", "space!", "21"]
-```
-
-#### new Bloodhound(options)
-The constructor function. It takes an [options hash](#options) as its only 
-argument.
-
-```javascript
-var engine = new Bloodhound({
-  local: ['dog', 'pig', 'moose'],
-  queryTokenizer: Bloodhound.tokenizers.whitespace,
-  datumTokenizer: Bloodhound.tokenizers.whitespace
-});
 ```
 
 ### Prefetch

--- a/doc/bloodhound.md
+++ b/doc/bloodhound.md
@@ -165,10 +165,12 @@ When instantiating a Bloodhound suggestion engine, there are a number of
 options you can configure.
 
 * `datumTokenizer` – A function with the signature `(datum)` that transforms a
-  datum into an array of string tokens. **Required**.
-
+  datum into an array of string tokens. **Required**. For built-in examples see
+  [Tokenizers](#tokenizers) or feel free to create your own.
+  
 * `queryTokenizer` – A function with the signature `(query)` that transforms a
-  query into an array of string tokens. **Required**.
+  query into an array of string tokens. **Required**. For built-in examples see 
+  [Tokenizers](#tokenizers) or feel free to create your own.
 
 * `initialize` – If set to `false`, the Bloodhound instance will not be 
   implicitly initialized by the constructor function. Defaults to `true`.
@@ -199,20 +201,21 @@ options you can configure.
 [compare function]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
 
 ### Tokenizers
-Bloodhound has various built-in tokenizer functions which can be used as a value for `datumTokenizer` and 
-`queryTokenizer` in the [options](#options). 
+Bloodhound has various built-in static tokenizer functions which can be used as a value for `datumTokenizer` and 
+`queryTokenizer` in [Options](#options). 
 
 #### Bloodhound.tokenizers.nonword(str)
-Splits the string `str` on any non alphanumeric characters or underscores using: `str.split(/\W+/)`
+Splits the string `str` on any nonword using: `str.split(/\W+/)`. A nonword includes all characters except alphanumeric 
+and underscores.
 
 ```javascript
-Bloodhound.tokenizers.nonword("I'll give bloodhound#0.11 a 8.5/10!");
+Bloodhound.tokenizers.nonword("I'll give bloodhound#0.11 a 8.5/10");
 //OUTPUT: ["I", "ll", "give", "bloodhound", "0", "11", "a", "8", "5", "10", ""]
 ```
 
 #### Bloodhound.tokenizers.whitespace(str)
 Splits the string `str` on any whitespaces using: `str.split(/\s+/)`. A whitespace includes spaces, tabs, carriage 
-returns, new line character, a vertical tab character & a form feed character
+returns, new line character, a vertical tab character and a form feed character.
 
 ```javascript
 Bloodhound.tokenizers.whitespace("I     like \t my space!");
@@ -220,7 +223,8 @@ Bloodhound.tokenizers.whitespace("I     like \t my space!");
 ```
 
 #### Bloodhound.tokenizers.obj.nonword([*keys])(obj)
-Performs the function [Bloodhound.tokenizers.nonword](#bloodhoundtokenizersnonword-keys-obj) on each key in `keys` 
+Takes an variadic argument `keys`, which contains the field name/s of `obj` that you wish to tokenize.  
+Performs the function [Bloodhound.tokenizers.nonword](#bloodhoundtokenizersnonword-str) on each of the `keys` 
 provided  on `obj` and then concatenates them.
 
 ```javascript
@@ -234,8 +238,9 @@ Bloodhound.tokenizers.obj.nonword("name", "message", "age")({
 ```
 
 #### Bloodhound.tokenizers.obj.whitespace([*keys])(obj)
-Performs the function `Bloodhound.tokenizers.whitespace` on each of the `keys` provided  on `obj` and then concatenates 
-them.
+Takes an variadic argument `keys`, which contains the field name/s of `obj` that you wish to tokenize.  
+Performs the function [Bloodhound.tokenizers.whitespace](#bloodhoundtokenizerswhitespace-str) on each of the `keys` 
+provided  on `obj` and then concatenates them.
 
 ```javascript
 Bloodhound.tokenizers.obj.whitespace("name", "message", "age")({ 


### PR DESCRIPTION
Quite a few important methods in Bloodhound has now been documented in the docs such as:
- Bloodhound.tokenizers.nonword
- Bloodhound.tokenizers.whitespace
- Bloodhound.tokenizers.obj.nonword
- Bloodhound.tokenizers.obj.whitespace
