### PR TITLE
make suggestions show when size drops to limit

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,7 +269,9 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          rendered += suggestions.length;
+          // if limit is 5 and suggestions.length is 5 - nothing will show :( 
+          // I am not sure what rendered does - but here, it keeps my suggestions from showing
+          // rendered += suggestions.length;
           that._append(query, suggestions.slice(0, that.limit - rendered));
 
           that.async && that.trigger('asyncReceived', query);


### PR DESCRIPTION
If suggestions.length drop to that.limit - no suggestions are showed. Clearly unintentionally wrong - but I'm not sure what rendered does so my 'hack' is a comment on the increment of rendered :(
