### PR TITLE
Fix #1368, bug if async results count equals limit

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,8 +269,8 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          rendered += suggestions.length;
-          that._append(query, suggestions.slice(0, that.limit - rendered));
+          rendered += Math.min(that.limit, suggestions.length);
+          that._append(query, suggestions.slice(0, that.limit));
 
           that.async && that.trigger('asyncReceived', query);
         }


### PR DESCRIPTION
If the number of async results matches `that.limit`, then we currently do `suggestions.slice(0, 0)`, resulting in no typeahead suggestions. I also fixed the rendered count calculation.
