### PR TITLE
Fix #1368, rendered count has to increase after rendering.

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,8 +269,8 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          rendered += suggestions.length;
           that._append(query, suggestions.slice(0, that.limit - rendered));
+          rendered += suggestions.length;
 
           that.async && that.trigger('asyncReceived', query);
         }


### PR DESCRIPTION
variable 'rendered' is increasing before rendering (call _append).
so, append fails to work properly. 
counting timing is fixed.
