### PR TITLE
Increase rendered count after appending suggestions

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,9 +269,9 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          rendered += suggestions.length;
-          that._append(query, suggestions.slice(0, that.limit - rendered));
-
+          var appendices = suggestions.slice(0, that.limit - rendered);
+          that._append(query, appendices);
+          rendered += appendices.length;
           that.async && that.trigger('asyncReceived', query);
         }
       }


### PR DESCRIPTION
Since only `that.limit - rendered` items are appended, the rendered count should be increased after the call to `that._append()`, and not before.
