### PR TITLE
This fixes the bug whereby if "that.limit - rendered" is not negative…

### DIFF
--- a/dist/typeahead.bundle.js
+++ b/dist/typeahead.bundle.js
@@ -1721,7 +1721,7 @@
                     if (!canceled && rendered < that.limit) {
                         that.cancel = $.noop;
                         rendered += suggestions.length;
-                        var negEnd = that.limit - rendered
+                        var negEnd = that.limit - rendered;
                         if (negEnd < 0) {
                             suggestions = suggestions.slice(0, negEnd);
                         }

--- a/dist/typeahead.bundle.js
+++ b/dist/typeahead.bundle.js
@@ -1721,7 +1721,11 @@
                     if (!canceled && rendered < that.limit) {
                         that.cancel = $.noop;
                         rendered += suggestions.length;
-                        that._append(query, suggestions.slice(0, that.limit - rendered));
+                        var negEnd = that.limit - rendered
+                        if (negEnd < 0) {
+                            suggestions = suggestions.slice(0, negEnd);
+                        }
+                        that._append(query, suggestions);
                         that.async && that.trigger("asyncReceived", query);
                     }
                 }

--- a/dist/typeahead.jquery.js
+++ b/dist/typeahead.jquery.js
@@ -808,7 +808,7 @@
                     if (!canceled && rendered < that.limit) {
                         that.cancel = $.noop;
                         rendered += suggestions.length;
-                        var negEnd = that.limit - rendered
+                        var negEnd = that.limit - rendered;
                         if (negEnd < 0) {
                             suggestions = suggestions.slice(0, negEnd);
                         }

--- a/dist/typeahead.jquery.js
+++ b/dist/typeahead.jquery.js
@@ -808,7 +808,11 @@
                     if (!canceled && rendered < that.limit) {
                         that.cancel = $.noop;
                         rendered += suggestions.length;
-                        that._append(query, suggestions.slice(0, that.limit - rendered));
+                        var negEnd = that.limit - rendered
+                        if (negEnd < 0) {
+                            suggestions = suggestions.slice(0, negEnd);
+                        }
+                        that._append(query, suggestions);
                         that.async && that.trigger("asyncReceived", query);
                     }
                 }

--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -270,8 +270,11 @@ var Dataset = (function() {
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
           rendered += suggestions.length;
-          that._append(query, suggestions.slice(0, that.limit - rendered));
-
+          var negEnd = that.limit - rendered
+          if (negEnd < 0) {
+              suggestions = suggestions.slice(0, negEnd);
+          }
+          that._append(query, suggestions);
           that.async && that.trigger('asyncReceived', query);
         }
       }

--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -270,7 +270,7 @@ var Dataset = (function() {
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
           rendered += suggestions.length;
-          var negEnd = that.limit - rendered
+          var negEnd = that.limit - rendered;
           if (negEnd < 0) {
               suggestions = suggestions.slice(0, negEnd);
           }


### PR DESCRIPTION
… then, used as the optional second parameter, 'end', to Array.slice (in this case, 'suggestions.slice(0, that.limit-rendered)')  it serves not as a the number of positions to count backward from the end of the array, but as the number of positions to count forwards to from the start of the array.  In the partcularly egregious case that occurred in my data-set, limit==10 and rendered==10 so suggestion.slice(0,limit-rendered) was suggestions.slice(0,0), an empty list, and I got no suggestions displayed at all when I typed in certain strings for which I knew there were many results. I think this bug may have crept in because of the programmer not appreciating how Arrray.slice handles parameter 'end' differently depending on whether it is negative or not.  From http://www.w3schools.com/jsref/jsref_slice_array.asp:

Syntax
 array.slice(start,end)

 Parameter  Description

  start Required.  

An integer that specifies where to start the selection (The first element has an index of 0). Use negative numbers to select from the end of an array

end Optional.  

An integer that specifies where to end the selection. If omitted, all elements from the start position and to the end of the array will be selected. Use negative numbers to select from the end of an array
