### PR TITLE
FIX: Typeahead "limit" if equal to results returned, shows "no-data"

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,9 +269,8 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          rendered += suggestions.length;
           that._append(query, suggestions.slice(0, that.limit - rendered));
-
+          rendered += suggestions.length;
           that.async && that.trigger('asyncReceived', query);
         }
       }


### PR DESCRIPTION
Merging into src files the changes suggested in issue #1299.
When suggestions length equals the limit, no data was shown, as slice was asked to cut zero elements.

The bug also caused strange behavior when suggestion's length is higher than limit, as negative indexes were introduced.
