### PR TITLE
remove handlbars dependency in custom template example

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -113,7 +113,7 @@
         </div>
 
         <div class="gist">
-          <script src="https://gist.github.com/jharding/9458780.js"></script>
+          <script src="https://gist.github.com/stevedesmond-ca/4872dc38b3c9d53dc414.js"></script>
         </div>
       </div>
 


### PR DESCRIPTION
In #1031, it was suggested that the example documentation not rely on Handlebars.js -- the referenced gist contains said adjustment, which can either be used directly, or merged into the original gist.

I'm not opposed to keeping handlebars in the example, but it seems like a good idea to show a little more of what's going on under the hood.
