### PR TITLE
bloodhound.md parameter in alphabetical order

### DIFF
--- a/doc/bloodhound.md
+++ b/doc/bloodhound.md
@@ -166,32 +166,32 @@ options you can configure.
 * `datumTokenizer` – A function with the signature `(datum)` that transforms a
   datum into an array of string tokens. **Required**.
 
-* `queryTokenizer` – A function with the signature `(query)` that transforms a
-  query into an array of string tokens. **Required**.
-
-* `initialize` – If set to `false`, the Bloodhound instance will not be 
-  implicitly initialized by the constructor function. Defaults to `true`.
-
 * `identify` – Given a datum, this function is expected to return a unique id
   for it. Defaults to `JSON.stringify`. Note that it is **highly recommended**
   to override this option.
 
-* `sufficient` – If the number of datums provided from the internal search 
-  index is less than `sufficient`, `remote` will be used to backfill search
-  requests triggered by calling `#search`. Defaults to `5`.
+* `initialize` – If set to `false`, the Bloodhound instance will not be
+  implicitly initialized by the constructor function. Defaults to `true`.
+
+* `local` – An array of data or a function that returns an array of data. The
+  data will be added to the internal search index when `#initialize` is called.
+
+* `prefetch` – Can be a URL to a JSON file containing an array of data or, if
+  more configurability is needed, a [prefetch options hash](#prefetch).
+
+* `queryTokenizer` – A function with the signature `(query)` that transforms a
+  query into an array of string tokens. **Required**.
+
+* `remote` – Can be a URL to fetch data from when the data provided by the
+  internal search index is insufficient or, if more configurability is needed,
+  a [remote options hash](#remote).
 
 * `sorter` – A [compare function] used to sort data returned from the internal
   search index.
 
-* `local` – An array of data or a function that returns an array of data. The 
-  data will be added to the internal search index when `#initialize` is called.
-
-* `prefetch` – Can be a URL to a JSON file containing an array of data or, if 
-  more configurability is needed, a [prefetch options hash](#prefetch).
-
-* `remote` – Can be a URL to fetch data from when the data provided by 
-  the internal search index is insufficient or, if more configurability is 
-  needed, a [remote options hash](#remote).
+* `sufficient` – If the number of datums provided from the internal search
+  index is less than `sufficient`, `remote` will be used to backfill search
+  requests triggered by calling `#search`. Defaults to `5`.
 
 <!-- section links -->
 
@@ -210,31 +210,31 @@ hitting [local storage limits].
 
 When configuring `prefetch`, the following options are available.
 
-* `url` – The URL prefetch data should be loaded from. **Required.**
+* `cacheKey` – The key that data will be stored in local storage under.
+  Defaults to value of `url`.
 
 * `cache` – If `false`, will not attempt to read or write to local storage and
-  will always load prefetch data from `url` on initialization.  Defaults to 
+  will always load prefetch data from `url` on initialization.  Defaults to
   `true`.
 
-* `ttl` – The time (in milliseconds) the prefetched data should be cached in 
-  local storage. Defaults to `86400000` (1 day).
-
-* `cacheKey` – The key that data will be stored in local storage under. 
-  Defaults to value of `url`.
+* `prepare` – A function that provides a hook to allow you to prepare the
+  settings object passed to `transport` when a request is about to be made. The
+  function signature should be `prepare(settings)` where `settings` is the
+  default settings object created internally by the Bloodhound instance. The
+  `prepare` function should return a settings object. Defaults to the [identity
+  function].
 
 * `thumbprint` – A string used for thumbprinting prefetched data. If this
   doesn't match what's stored in local storage, the data will be refetched.
 
-* `prepare` – A function that provides a hook to allow you to prepare the 
-  settings object passed to `transport` when a request is about to be made. 
-  The function signature should be `prepare(settings)` where `settings` is the 
-  default settings object created internally by the Bloodhound instance. The 
-  `prepare` function should return a settings object. Defaults to the 
-  [identity function].
-
 * `transform` – A function with the signature `transform(response)` that allows
-  you to transform the prefetch response before the Bloodhound instance operates 
-  on it. Defaults to the [identity function].
+  you to transform the prefetch response before the Bloodhound instance
+  operates on it. Defaults to the [identity function].
+
+* `ttl` – The time (in milliseconds) the prefetched data should be cached in
+  local storage. Defaults to `86400000` (1 day).
+
+* `url` – The URL prefetch data should be loaded from. **Required.**
 
 <!-- section links -->
 
@@ -249,28 +249,28 @@ of requests being made to the remote endpoint, requests are rate-limited.
 
 When configuring `remote`, the following options are available.
 
-* `url` – The URL remote data should be loaded from. **Required.**
+* `prepare` – A function that provides a hook to allow you to prepare the
+  settings object passed to `transport` when a request is about to be made. The
+  function signature should be `prepare(query, settings)`, where `query` is the
+  query `#search` was called with and `settings` is the default settings object
+  created internally by the Bloodhound instance. The `prepare` function should
+  return a settings object. Defaults to the [identity function].
 
-* `prepare` – A function that provides a hook to allow you to prepare the 
-  settings object passed to `transport` when a request is about to be made. 
-  The function signature should be `prepare(query, settings)`, where `query` is
-  the query `#search` was called with and `settings` is the default settings
-  object created internally by the Bloodhound instance. The `prepare` function
-  should return a settings object. Defaults to the [identity function].
+* `rateLimitBy` – The method used to rate-limit network requests. Can be either
+  `debounce` or `throttle`. Defaults to `debounce`.
+
+* `rateLimitWait` – The time interval in milliseconds that will be used by
+  `rateLimitBy`. Defaults to `300`.
+
+* `transform` – A function with the signature `transform(response)` that allows
+  you to transform the remote response before the Bloodhound instance operates
+  on it. Defaults to the [identity function].
+
+* `url` – The URL remote data should be loaded from. **Required.**
 
 * `wildcard` – A convenience option for `prepare`. If set, `prepare` will be a
   function that replaces the value of this option in `url` with the URI encoded
   query.
-
-* `rateLimitBy` – The method used to rate-limit network requests. Can be either 
-  `debounce` or `throttle`. Defaults to `debounce`.
-
-* `rateLimitWait` – The time interval in milliseconds that will be used by 
-  `rateLimitBy`. Defaults to `300`.
-
-* `transform` – A function with the signature `transform(response)` that allows
-  you to transform the remote response before the Bloodhound instance operates 
-  on it. Defaults to the [identity function].
 
 <!-- section links -->
 


### PR DESCRIPTION
Hi,

This PR proposes to put parameters in bloodhound.md in alphabetical order, this would help readers who are not familiar with the library to find parameters faster.

Please feel free to reject this if you think is not a good idea.

Best regards,
Francesc
