### PR TITLE
Fix limit bug when async update occurs

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,9 +269,10 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          rendered += suggestions.length;
-          that._append(query, suggestions.slice(0, that.limit - rendered));
-
+          var suggestionsToAppend = suggestions.slice(0, that.limit - rendered);
+          that._append(query, suggestionsToAppend);
+          rendered += suggestionsToAppend.length;   
+      
           that.async && that.trigger('asyncReceived', query);
         }
       }


### PR DESCRIPTION
When having 0 rendered suggestions, a limit of 5 and a suggestions array with length of 5, nothing will be rendered.
This is due to the fact that the "rendered" variable is updated before the suggestions are sliced.
With the given PR, everything works as expected.
