### PR TITLE
Fixing bug when suggestions length is less than the limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ Grunt tasks that'll be useful in development.
   Useful for using *test/playground.html* for debugging/testing.
 * `grunt dev` – Runs `grunt watch` and `grunt server` in parallel.
 
+You'll also need to install Bower with `npm install -g bower` and run `bower install`
+in order to get some other developer dependencies.
+
 <!-- section links -->
 
 [contributing guidelines]: https://github.com/twitter/typeahead.js/blob/master/CONTRIBUTING.md

--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -271,11 +271,10 @@ var Dataset = (function() {
           that.cancel = $.noop;
           rendered += suggestions.length;
 
-          var results = suggestions;
           if (that.limit < rendered) {
-            results = results.slice(0, that.limit - rendered);
+            suggestions = suggestions.slice(0, that.limit - rendered);
           }
-          that._append(query, results);
+          that._append(query, suggestions);
 
           that.async && that.trigger('asyncReceived', query);
         }

--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -270,7 +270,12 @@ var Dataset = (function() {
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
           rendered += suggestions.length;
-          that._append(query, suggestions.slice(0, that.limit - rendered));
+
+          var results = suggestions;
+          if (that.limit < rendered) {
+            results = results.slice(0, that.limit - rendered);
+          }
+          that._append(query, results);
 
           that.async && that.trigger('asyncReceived', query);
         }

--- a/test/typeahead/dataset_spec.js
+++ b/test/typeahead/dataset_spec.js
@@ -376,6 +376,21 @@ describe('Dataset', function() {
 
       waitsFor(function() { return spy.callCount; });
     });
+
+    it('should render all the results if results length is less than limit', function() {
+      this.dataset.async = true;
+
+      this.dataset.limit = 9;
+      this.source.andCallFake(fakeGetWithAsyncSuggestions);
+
+      this.dataset.update('woah');
+
+      waits(100);
+
+      runs(function() {
+        expect(this.dataset.$el.find('.tt-suggestion')).toHaveLength(8);
+      });
+    });
   });
 
   describe('#clear', function() {


### PR DESCRIPTION
A bug occurs when the number of suggestions is less than the limit.
Before, async update would give back `suggestions.slice(0, limit -
rendered)` but in cases where number of rendered suggestions is less
than limit, this would result in missing suggestions.

e.g. Say the limit is 5 and the list of suggestions for my query `"foo"`
comes back as `["food", "fool", "foot"]`, this would result in appending
`["food", "fool", "foot"].splice(0, 5 - 3) //=> ["food", "fool"]` which
is missing the legitimate suggestion "foot".

Also in setting this up locally I scratched my head for a bit before figuring out that I needed to install Bower and run `bower install`. Updated the README to include those instructions.
