### PR TITLE
Set aria-hidden on hint input

### DIFF
--- a/src/typeahead/plugin.js
+++ b/src/typeahead/plugin.js
@@ -220,7 +220,7 @@
     .css(getBackgroundStyles($input))
     .prop('readonly', true)
     .removeAttr('id name placeholder required')
-    .attr({ autocomplete: 'off', spellcheck: 'false', tabindex: -1 });
+    .attr({ autocomplete: 'off', spellcheck: 'false', tabindex: -1, 'aria-hidden': 'true' });
   }
 
   function prepInput($input, www) {


### PR DESCRIPTION
Without this aria information, screen readers like JAWS select the hint input before the real input when navigating the page with arrow keys. This is really confusing for people as they don't understand why a search field need two inputs.
