### PR TITLE
Fix insecure content warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>typeahead.js</title>
     <meta name="description" content="a fast and fully-featured autocomplete library">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="shortcut icon" type="image/x-icon" href="http://twitter.com/favicons/favicon.ico">
+    <link rel="shortcut icon" type="image/x-icon" href="https://twitter.com/favicons/favicon.ico">
     <link rel="stylesheet" href="css/normalize.min.css">
     <link rel="stylesheet" href="css/main.css">
     <base target="_blank">


### PR DESCRIPTION
Fix insecure content warning due to favicon in typeahead.js docs
