### PR TITLE
Declaration of wrong variable

### DIFF
--- a/js/examples.js
+++ b/js/examples.js
@@ -5,7 +5,7 @@ $(document).ready(function() {
 
   var substringMatcher = function(strs) {
     return function findMatches(q, cb) {
-      var matches, substringRegex;
+      var matches, substrRegex;
 
       // an array that will be populated with substring matches
       matches = [];


### PR DESCRIPTION
The variable `substringRegex` but instead it should be `substrRegex`.
Minor typo, but outputs error if using `'use strict'`.
