### PR TITLE
Change getting arrays intersection

### DIFF
--- a/src/bloodhound/search_index.js
+++ b/src/bloodhound/search_index.js
@@ -163,29 +163,8 @@ var SearchIndex = window.SearchIndex = (function() {
   }
 
   function getIntersection(arrayA, arrayB) {
-    var ai = 0, bi = 0, intersection = [];
-
-    arrayA = arrayA.sort();
-    arrayB = arrayB.sort();
-
-    var lenArrayA = arrayA.length, lenArrayB = arrayB.length;
-
-    while (ai < lenArrayA && bi < lenArrayB) {
-      if (arrayA[ai] < arrayB[bi]) {
-        ai++;
-      }
-
-      else if (arrayA[ai] > arrayB[bi]) {
-        bi++;
-      }
-
-      else {
-        intersection.push(arrayA[ai]);
-        ai++;
-        bi++;
-      }
-    }
-
-    return intersection;
+    return arrayA.filter(function (n) {
+                return arrayB.indexOf(n) !== -1;
+            });
   }
 })();


### PR DESCRIPTION
Fix getting array intersection.

How bug was found: 
arrayA = [5509, 5, 1068, 3563, 5061, 458], arrayB = [1788, 5509, 5, 1068, 1754, 5061, 458]

expected : intersection = [5509, 5, 1068, 5061, 458]
current :  intersection = [1068, 5061, 5509]
