### PR TITLE
workaround for ie11 crash

### DIFF
--- a/src/typeahead/input.js
+++ b/src/typeahead/input.js
@@ -264,7 +264,15 @@ var Input = (function() {
       // 2 is arbitrary, just picking a small number to handle edge cases
       var constraint = this.$input.width() - 2;
 
-      this.$overflowHelper.text(this.getInputValue());
+      // ie11 crashes here, see won't fix issue from ms...
+      // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/175640/
+      // above says fixed in newer versions of ie11 but still crashing in
+      // latest ie11.  below is workaround recommended in link above.
+      if (_.isMsie()) {
+          this.$overflowHelper[0].innerText = this.getInputValue();
+      } else {
+          this.$overflowHelper.text(this.getInputValue());
+      }
 
       return this.$overflowHelper.width() >= constraint;
     },


### PR DESCRIPTION
IE11 (even most recent versions) is crashing (with segmentation fault) when typeahead results have dash in them.  For example, having search result of "test-test".  Then in typeahead input type "test-" then delete dash and crash occurs.

Links below, say it is "won't fix" by MS, so applying recommended workaround in this PR.

https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/175640/
https://connect.microsoft.com/IE/feedback/details/851144/assigning-textcontent-crashes-the-browser-tab
