### PR TITLE
jquery3: Fix compatibility with jQuery 3

### DIFF
--- a/src/bloodhound/persistent_storage.js
+++ b/src/bloodhound/persistent_storage.js
@@ -130,7 +130,7 @@ var PersistentStorage = (function() {
   }
 
   function decode(val) {
-    return $.parseJSON(val);
+    return JSON.parse(val);
   }
 
   function gatherMatchingKeys(keyMatcher) {

--- a/src/typeahead/plugin.js
+++ b/src/typeahead/plugin.js
@@ -219,7 +219,8 @@
     .css(www.css.hint)
     .css(getBackgroundStyles($input))
     .prop('readonly', true)
-    .removeAttr('id name placeholder required')
+    .prop('required', false)
+    .removeAttr('id name placeholder')
     .attr({ autocomplete: 'off', spellcheck: 'false', tabindex: -1 });
   }
 

--- a/test/fixtures/ajax_responses.js
+++ b/test/fixtures/ajax_responses.js
@@ -15,5 +15,5 @@ fixtures.ajaxResps = {
 };
 
 $.each(fixtures.ajaxResps, function(i, resp) {
-  resp.responseText && (resp.parsed = $.parseJSON(resp.responseText));
+  resp.responseText && (resp.parsed = JSON.parse(resp.responseText));
 });


### PR DESCRIPTION
- Use JSON.parse() instead of $.parseJSON()
- $.prop('required, false) instead of .removeAttr('required')
