### PR TITLE
correctly respect limit in async mode

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,8 +269,8 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          rendered += suggestions.length;
           that._append(query, suggestions.slice(0, that.limit - rendered));
+          rendered += suggestions.length;
 
           that.async && that.trigger('asyncReceived', query);
         }


### PR DESCRIPTION
swapped two lines because otherwise the first page of results is never shown because the counter is incremented prematurely

I hope this explanation is enough - if needed I can create a minimal demo
