### PR TITLE
Fix wrong number of suggestions displayed sometimes

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,8 +269,8 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          rendered += suggestions.length;
           that._append(query, suggestions.slice(0, that.limit - rendered));
+          rendered += suggestions.length;
 
           that.async && that.trigger('asyncReceived', query);
         }


### PR DESCRIPTION
When you set the limit: param to number of suggestions and the results from ajax are less than limit: the number of suggestions displayed was actually <limit> - <results count>.
This is a shift by one bug.

It's a one line fix. I did not compile and include dist files in the fix to keep fix clear.
