### PR TITLE
add .abort to async cancel that it shows in network console as aborted

### DIFF
--- a/src/bloodhound/transport.js
+++ b/src/bloodhound/transport.js
@@ -61,7 +61,7 @@ var Transport = (function() {
 
       // a request is already in progress, piggyback off of it
       if (jqXhr = pendingRequests[fingerprint]) {
-        jqXhr.done(done).fail(fail);
+        jqXhr.done(done).fail(fail).abort();
       }
 
       // under the pending request threshold, so fire off a request


### PR DESCRIPTION
the aborted requests were no showing in network console and so my team leader couldnt see proven that the request was cancelled effectively. as with a previous library that used abort.  Saw async:cancelrequest event fire in console.log but not in the network

. with .fail.done. added .abort()
let me know if there is a reason why would not use abort.

Thanks,
//mh

