### PR TITLE
skip highlight

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -198,6 +198,7 @@ var Dataset = (function() {
 
       this.highlight && highlight({
         className: this.classes.highlight,
+        skipHighlight: this.classes.skipHighlight,
         node: fragment,
         pattern: query
       });

--- a/src/typeahead/highlight.js
+++ b/src/typeahead/highlight.js
@@ -6,17 +6,18 @@
 
 // inspired by https://github.com/jharding/bearhug
 
-var highlight = (function(doc) {
+var highlight = (function (doc) {
   'use strict';
 
   var defaults = {
-        node: null,
-        pattern: null,
-        tagName: 'strong',
-        className: null,
-        wordsOnly: false,
-        caseSensitive: false
-      };
+    node: null,
+    pattern: null,
+    tagName: 'strong',
+    className: null,
+    skipHighlight: null,
+    wordsOnly: false,
+    caseSensitive: false
+  };
 
   return function hightlight(o) {
     var regex;
@@ -57,7 +58,9 @@ var highlight = (function(doc) {
       for (var i = 0; i < el.childNodes.length; i++) {
         childNode = el.childNodes[i];
 
-        if (childNode.nodeType === TEXT_NODE_TYPE) {
+        if ($(childNode).hasClass(o.skipHighlight)) {
+          continue;
+        } else if (childNode.nodeType === TEXT_NODE_TYPE) {
           i += hightlightTextNode(childNode) ? 1 : 0;
         }
 

--- a/src/typeahead/www.js
+++ b/src/typeahead/www.js
@@ -18,7 +18,8 @@ var WWW = (function() {
     empty: 'tt-empty',
     open: 'tt-open',
     cursor: 'tt-cursor',
-    highlight: 'tt-highlight'
+    highlight: 'tt-highlight',
+    skipHighlight: 'tt-skip-highlight'
   };
 
   return build;


### PR DESCRIPTION
the possibility to skip highlighting some part of the suggestion, it is
specially usefull when using material icons, where the icons would be
highlighted and the icon would be gone in the current version, this
change is to adress this issue,

```HTML
<i class="material-icon">menu</i> ==> <i class="material-icon"><strong>me</strong>nu</i> 
```
this transformation is false, the highlighting mecanism should ignore menu.