### PR TITLE
Fix the suggestion list count display

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,9 +269,8 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          rendered += suggestions.length;
           that._append(query, suggestions.slice(0, that.limit - rendered));
-
+          rendered += suggestions.length;
           that.async && that.trigger('asyncReceived', query);
         }
       }


### PR DESCRIPTION
When you have limit=5, 3 results length for suggestions and 0 rendered, for example, then you only render 2 results.
because 
rendered += suggestions.length; // 0+=3; rendered= 3
that._append(query, suggestions.slice(0, 5 - 3)); // that._append(query, suggestions.slice(0, 2));

When the lines are swape
that._append(query, suggestions.slice(0, 5 - 0)); // that._append(query, suggestions.slice(0, 5));
rendered += suggestions.length; // 0+=3; rendered= 3