### PR TITLE
Update class to suit newer versions

### DIFF
--- a/test/playground.html
+++ b/test/playground.html
@@ -15,7 +15,7 @@
         margin: 50px 0;
       }
 
-      .tt-dropdown-menu {
+      .tt-menu {
         background-color: #fff;
         border: 1px solid #000;
       }


### PR DESCRIPTION
.tt-dropdown-menu class been changed to .tt-menu in newer versions of typeahead, although that is not reflected in the playground file, thus causing some minor design issues.