### PR TITLE
Datum tokenizer on example fixed

### DIFF
--- a/doc/bloodhound.md
+++ b/doc/bloodhound.md
@@ -122,7 +122,7 @@ Returns the data in the local search index corresponding to `ids`.
     local: [{ id: 1, name: 'dog' }, { id: 2, name: 'pig' }],
     identify: function(obj) { return obj.id; },
     queryTokenizer: Bloodhound.tokenizers.whitespace,
-    datumTokenizer: Bloodhound.tokenizers.whitespace
+    datumTokenizer: Bloodhound.tokenizers.obj.whitespace('name')
   });
 
   engine.get([1, 3]); // [{ id: 1, name: 'dog' }, null]


### PR DESCRIPTION
The datumTokenizer was using the whitespace tokenizer, but that does not work with each datum item being an object with id and name properties.