### PR TITLE
Fix broken "Built with Grunt" badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![build status](https://secure.travis-ci.org/twitter/typeahead.js.svg?branch=master)](http://travis-ci.org/twitter/typeahead.js)
-[![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com/)
+[![Built with Grunt](https://gruntjs.com/cdn/builtwith.svg)](http://gruntjs.com/)
 
 
 [typeahead.js][gh-page]


### PR DESCRIPTION
Fix broken "Built with Grunt" badge in README.md.

Current link, with certificate problems: https://cdn.gruntjs.com/builtwith.png
New link, working: https://gruntjs.com/cdn/builtwith.svg