### PR TITLE
Fix limit on async suggestions

### DIFF
--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,8 +269,9 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          that._append(query, suggestions.slice(0, that.limit - rendered));
-          rendered += suggestions.length;
+          var appended = that.limit - rendered;
+          that._append(query, suggestions.slice(0, appended));
+          rendered += appended;
           that.async && that.trigger('asyncReceived', query);
         }
       }

--- a/src/typeahead/dataset.js
+++ b/src/typeahead/dataset.js
@@ -269,9 +269,8 @@ var Dataset = (function() {
         // do not render the suggestions as they've become outdated
         if (!canceled && rendered < that.limit) {
           that.cancel = $.noop;
-          rendered += suggestions.length;
           that._append(query, suggestions.slice(0, that.limit - rendered));
-
+          rendered += suggestions.length;
           that.async && that.trigger('asyncReceived', query);
         }
       }


### PR DESCRIPTION
On async responses with multiple results the current code has bug that subtracts the number of results *before* slicing the required number to complete the limit.
